### PR TITLE
Cookie Consent Instance Initiation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import 'vanilla-cookieconsent/dist/cookieconsent.css';
 import * as CookieConsent from 'vanilla-cookieconsent';
 
+// Create a cookie consent instance
+const cc = CookieConsent.initCookieConsent();
+
 // Default configuration
 const defaultConfig = {
     current_lang: 'en',
@@ -90,4 +93,4 @@ if (typeof window.sccSettings !== 'undefined') {
 }
 
 // Initialize with the merged configuration
-CookieConsent.run(config);
+cc.run(config);


### PR DESCRIPTION
This pull request includes changes to the `src/index.js` file to initialize the cookie consent instance in a more structured manner.

* Created a cookie consent instance using `CookieConsent.initCookieConsent()` and assigned it to the `cc` variable.
* Updated the initialization call to use the new `cc` instance instead of directly using `CookieConsent.run(config)`.