### PR TITLE
correction to readme.md for category script attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ The default configuration includes:
 
 ### Blocking Google Analytics Until Consent
 
-Add your Google Analytics script with the `data-cookiecategory` attribute:
+Add your Google Analytics script with the `data-category` attribute:
 
 ```html
-<script type="text/plain" data-cookiecategory="analytics">
+<script type="text/plain" data-category="analytics">
   // Your Google Analytics code here
 </script>
 ```


### PR DESCRIPTION
Nice project 👍 
Think that the attribute should be `data-category` rather than `data-cookiecategory` per https://cookieconsent.orestbida.com/advanced/manage-scripts.html#how-to-block-manage-a-script-tag