### PR TITLE
Composer Update

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,6 +4,7 @@
 
 # Development files
 .DS_Store
+.gitattributes
 .gitignore
 .distignore
 phpcs.xml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Exclude development files from Composer installs and git archives
+.git export-ignore
+.github export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.distignore export-ignore
+.claude export-ignore
+.DS_Store export-ignore
+.vscode export-ignore
+.idea export-ignore
+
+phpcs.xml export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+package.json export-ignore
+package-lock.json export-ignore
+webpack.config.js export-ignore
+
+src export-ignore
+node_modules export-ignore
+vendor export-ignore
+docs export-ignore
+
+AGENTS.md export-ignore
+CLAUDE.md export-ignore
+README.md export-ignore
+dev.md export-ignore
+
+*.sh export-ignore
+*.log export-ignore
+*.swp export-ignore
+*.swo export-ignore
+*~ export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Simple Cookie Consent are documented here.
 
+## [1.2.1] - 2026-05-26
+
+### Fixed
+- `composer.json` license corrected from MIT to GPL-2.0-or-later to match plugin header and LICENSE.md
+- `composer.json` support URLs were pointing to wrong repository (carousel-block → simple-cookie-consent)
+
+### Added
+- `.gitattributes` with `export-ignore` directives to exclude dev files from Composer installs and git archives — resolves Plugin Check false-positive warnings when installing via Composer
+
 ## [1.2.0] - 2026-05-26
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "imagewize/simple-cookie-consent",
     "description": "Implements GDPR-compliant cookie consent functionality.",
     "type": "wordpress-plugin",
-    "license": "MIT",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Jasper Frumau",
@@ -20,8 +20,8 @@
         "consent"
     ],
     "support": {
-        "issues": "https://github.com/imagewize/carousel-block/issues",
-        "source": "https://github.com/imagewize/carousel-block"
+        "issues": "https://github.com/imagewize/simple-cookie-consent/issues",
+        "source": "https://github.com/imagewize/simple-cookie-consent"
     },
     "require": {
         "php": ">=8.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -58,6 +58,13 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 
 == Changelog ==
 
+= 1.2.1 =
+*2026-05-26*
+
+* Fixed composer.json license field (MIT → GPL-2.0-or-later) to match plugin header
+* Fixed composer.json support URLs pointing to wrong repository
+* Added .gitattributes to exclude dev files from Composer installs and git archives
+
 = 1.2.0 =
 *2026-05-26*
 
@@ -86,6 +93,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.2.1 =
+Fixes composer.json license and support URLs; adds .gitattributes for Composer installs.
 
 = 1.2.0 =
 Adds a floating preferences toggle button so visitors can revisit their cookie choices at any time.

--- a/simple-cookie-consent.php
+++ b/simple-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Simple Cookie Consent
  * Description: Implements GDPR-compliant cookie consent functionality.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Text Domain: simple-cookie-consent


### PR DESCRIPTION
This release delivers v1.2.1, a maintenance update focused on correcting package metadata and improving Composer distribution quality. The `composer.json` file contained incorrect license identifiers and malformed support/repository URLs that would have caused issues for consumers installing the package via Packagist. A `.gitattributes` file has been introduced to define export-ignore rules, ensuring that development-only files are excluded from Composer archive exports. The version bump is reflected consistently across `simple-cookie-consent.php`, `readme.txt`, and `CHANGELOG.md`.

**Package Metadata Corrections:**
- Corrected the `license` field and `support`/`homepage` URLs in `composer.json` to accurately reference the plugin's repository and support channels, resolving discrepancies that could affect Packagist display and downstream tooling.

**Composer Distribution Quality:**
- Added `.gitattributes` with `export-ignore` directives to prevent development artifacts (e.g., source files, configuration, and tooling) from being included in Composer distribution archives, reducing package size for end users.

**Version and Changelog Tracking:**
- Incremented the plugin version to 1.2.1 in `simple-cookie-consent.php` and `readme.txt`, and added a corresponding entry to `CHANGELOG.md` documenting the scope of this patch release.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/simple-cookie-consent/blob/composer-update/CHANGELOG.md) (Modified)
- [`composer.json`](https://github.com/imagewize/simple-cookie-consent/blob/composer-update/composer.json) (Modified)
- [`readme.txt`](https://github.com/imagewize/simple-cookie-consent/blob/composer-update/readme.txt) (Modified)
- [`simple-cookie-consent.php`](https://github.com/imagewize/simple-cookie-consent/blob/composer-update/simple-cookie-consent.php) (Modified)
- [`.gitattributes`](https://github.com/imagewize/simple-cookie-consent/blob/composer-update/.gitattributes) (Added)