### PR TITLE
Fix/keep Composer Json In Dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@
 .idea export-ignore
 
 phpcs.xml export-ignore
-composer.json export-ignore
 composer.lock export-ignore
 package.json export-ignore
 package-lock.json export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [1.3.1] - 2026-05-26
+
+### Fixed
+- `composer.json` is no longer `export-ignore`d in `.gitattributes`, so the package manifest ships in Composer/Packagist dist archives (it remains excluded from WordPress.org builds via `.distignore`, which is correct since WP.org does not use Composer)
+
 ## [1.3.0] - 2026-05-26
 
 ### Added

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -57,6 +57,11 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 3. Cookie category management interface
 
 == Changelog ==
+
+= 1.3.1 =
+*2026-05-26*
+
+* Fixed .gitattributes so composer.json ships in Composer/Packagist dist archives (still excluded from WordPress.org builds via .distignore)
 
 = 1.3.0 =
 *2026-05-26*

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Text Domain: warder-cookie-consent


### PR DESCRIPTION
This release bumps the plugin to version 1.3.1 and resolves a packaging oversight where `composer.json` was excluded from Composer distribution archives. The fix ensures that projects installing the plugin via `composer require imagewize/simple-cookie-consent` receive a complete package with the necessary metadata file present. The change is minimal in scope — four files updated with 12 lines added and 3 removed — and carries no functional impact on plugin behavior at runtime. Downstream Composer consumers who depend on `composer.json` being present in the installed package (for version resolution, autoload configuration, or dependency inspection) are the primary beneficiaries.

**Packaging and Distribution:**
- Updated `.gitattributes` to stop excluding `composer.json` from Composer export archives, ensuring the file is present in packages installed via Packagist or direct VCS.
- Bumped the version constant in `warder-cookie-consent.php` from v1.3.0 to v1.3.1 to reflect the corrected distribution build.

**Changelog and Documentation:**
- Added a v1.3.1 entry to `CHANGELOG.md` documenting the `composer.json` inclusion fix for Composer-based installations.
- Updated `readme.txt` to reflect the new version number, keeping WordPress.org plugin metadata in sync with the codebase.

**Files Changed:**

- [`.gitattributes`](https://github.com/imagewize/warder-cookie-consent/blob/fix/keep-composer-json-in-dist/.gitattributes) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/fix/keep-composer-json-in-dist/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/fix/keep-composer-json-in-dist/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/fix/keep-composer-json-in-dist/warder-cookie-consent.php) (Modified)