### PR TITLE
Fix/restore Category Cookie Handlers

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -20,3 +20,10 @@ jobs:
           build-dir: '${{ github.workspace }}/plugin-build/warder-cookie-consent'
           checks: ''
           exclude-checks: 'EnqueuedScriptsScope'
+
+      - name: Upload Plugin Check Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: plugin-check-results
+          path: ${{ github.workspace }}/plugin-build/warder-cookie-consent/plugin-check-results.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to Warder Cookie Consent are documented here.
 - "Delete Category" link in each non-necessary category header so the delete-category action is reachable from the UI
 - `Requires at least` (5.0) and `Requires PHP` (8.0) headers in the main plugin file so WordPress can enforce minimum-version compatibility at activation
 
+### Changed
+- Wrapped all hardcoded admin settings-page strings (section headings, field labels, descriptions, select options, buttons, placeholders, and confirm dialogs) in `esc_html_e()` / `esc_attr_e()` / `esc_html__()` / `esc_js()` with the `warder-cookie-consent` text domain — they are now translatable and escaped on output, and pass the `WordPress.WP.I18n` sniff
+
 ### Fixed
 - The "Add New Category", "Add Cookie", and "Remove" cookie controls were rendering but had no backend handler after the earlier form refactor — clicking them did nothing. They now work again
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [1.4.0] - 2026-05-27
+
+### Added
+- Restored the cookie category and cookie management actions in the settings page, now consolidated in `warder_handle_admin_actions()`: add a new category, add a cookie to a category, delete a cookie, and delete a category — each guarded by a dedicated nonce (`check_admin_referer()` / `wp_verify_nonce()`) and sanitized with `sanitize_key()` / `sanitize_text_field()` / `absint()`
+- "Delete Category" link in each non-necessary category header so the delete-category action is reachable from the UI
+- `Requires at least` (5.0) and `Requires PHP` (8.0) headers in the main plugin file so WordPress can enforce minimum-version compatibility at activation
+
+### Fixed
+- The "Add New Category", "Add Cookie", and "Remove" cookie controls were rendering but had no backend handler after the earlier form refactor — clicking them did nothing. They now work again
+
 ## [1.3.2] - 2026-05-27
 
 ### Fixed

--- a/languages/warder-cookie-consent.pot
+++ b/languages/warder-cookie-consent.pot
@@ -1,0 +1,349 @@
+# Copyright (C) 2026 Jasper Frumau
+# This file is distributed under the GPLv2 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Warder Cookie Consent 1.4.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/warder-cookie-consent\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-05-27T00:18:47+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: warder-cookie-consent\n"
+
+#. Plugin Name of the plugin
+#: warder-cookie-consent.php
+msgid "Warder Cookie Consent"
+msgstr ""
+
+#. Description of the plugin
+#: warder-cookie-consent.php
+msgid "GDPR-compliant cookie consent banner with category management and floating preferences toggle."
+msgstr ""
+
+#. Author of the plugin
+#: warder-cookie-consent.php
+msgid "Jasper Frumau"
+msgstr ""
+
+#. Author URI of the plugin
+#: warder-cookie-consent.php
+msgid "https://imagewize.com"
+msgstr ""
+
+#: warder-cookie-consent.php:301
+msgid "Settings saved successfully."
+msgstr ""
+
+#: warder-cookie-consent.php:310
+msgid "General Settings"
+msgstr ""
+
+#: warder-cookie-consent.php:313
+msgid "Enable Plugin"
+msgstr ""
+
+#: warder-cookie-consent.php:317
+msgid "Display the cookie consent banner on the frontend"
+msgstr ""
+
+#: warder-cookie-consent.php:322
+msgid "Language"
+msgstr ""
+
+#: warder-cookie-consent.php:325
+msgid "English"
+msgstr ""
+
+#: warder-cookie-consent.php:326
+msgid "French"
+msgstr ""
+
+#: warder-cookie-consent.php:327
+msgid "German"
+msgstr ""
+
+#: warder-cookie-consent.php:328
+msgid "Spanish"
+msgstr ""
+
+#: warder-cookie-consent.php:329
+msgid "Italian"
+msgstr ""
+
+#: warder-cookie-consent.php:330
+msgid "Dutch"
+msgstr ""
+
+#: warder-cookie-consent.php:332
+msgid "Default language for the cookie consent banner. For more languages, you'll need to modify the src/index.js file."
+msgstr ""
+
+#: warder-cookie-consent.php:336
+msgid "Auto-clear Cookies"
+msgstr ""
+
+#: warder-cookie-consent.php:340
+msgid "Automatically clear cookies when user rejects them"
+msgstr ""
+
+#: warder-cookie-consent.php:345
+msgid "Page Scripts"
+msgstr ""
+
+#: warder-cookie-consent.php:349
+msgid "Control script execution based on user consent"
+msgstr ""
+
+#: warder-cookie-consent.php:354
+msgid "Preferences Toggle Button"
+msgstr ""
+
+#: warder-cookie-consent.php:358
+msgid "Show a floating button to reopen cookie preferences"
+msgstr ""
+
+#: warder-cookie-consent.php:360
+msgid "Displays a cookie icon button that lets users revisit their consent choices at any time."
+msgstr ""
+
+#: warder-cookie-consent.php:363
+msgid "Bottom Right"
+msgstr ""
+
+#: warder-cookie-consent.php:364
+msgid "Bottom Left"
+msgstr ""
+
+#: warder-cookie-consent.php:365
+msgid "Top Right"
+msgstr ""
+
+#: warder-cookie-consent.php:366
+msgid "Top Left"
+msgstr ""
+
+#: warder-cookie-consent.php:368
+msgid "Corner where the floating button appears."
+msgstr ""
+
+#: warder-cookie-consent.php:374
+msgid "Consent Modal"
+msgstr ""
+
+#: warder-cookie-consent.php:377
+#: warder-cookie-consent.php:455
+msgid "Title"
+msgstr ""
+
+#: warder-cookie-consent.php:380
+msgid "Title displayed in the cookie consent banner."
+msgstr ""
+
+#: warder-cookie-consent.php:384
+#: warder-cookie-consent.php:466
+msgid "Description"
+msgstr ""
+
+#: warder-cookie-consent.php:387
+msgid "Main description explaining cookie usage on your site."
+msgstr ""
+
+#: warder-cookie-consent.php:391
+msgid "Primary Button"
+msgstr ""
+
+#: warder-cookie-consent.php:395
+msgid "Accept All"
+msgstr ""
+
+#: warder-cookie-consent.php:396
+msgid "Accept Selected"
+msgstr ""
+
+#: warder-cookie-consent.php:398
+msgid "Primary action button for the consent banner."
+msgstr ""
+
+#: warder-cookie-consent.php:402
+msgid "Secondary Button"
+msgstr ""
+
+#: warder-cookie-consent.php:406
+msgid "Accept Necessary"
+msgstr ""
+
+#: warder-cookie-consent.php:407
+#: warder-cookie-consent.php:474
+msgid "Settings"
+msgstr ""
+
+#: warder-cookie-consent.php:409
+msgid "Secondary action button for the consent banner."
+msgstr ""
+
+#: warder-cookie-consent.php:413
+msgid "Privacy Policy URL"
+msgstr ""
+
+#: warder-cookie-consent.php:416
+msgid "Link to your privacy policy page. Default: #privacy-policy"
+msgstr ""
+
+#: warder-cookie-consent.php:422
+msgid "Cookie Categories"
+msgstr ""
+
+#: warder-cookie-consent.php:423
+msgid "Configure cookie categories and specific cookies to be blocked until consent is given."
+msgstr ""
+
+#: warder-cookie-consent.php:449
+msgid "Delete this entire category and its cookies?"
+msgstr ""
+
+#: warder-cookie-consent.php:449
+msgid "Delete Category"
+msgstr ""
+
+#: warder-cookie-consent.php:462
+#: warder-cookie-consent.php:818
+msgid "The name displayed to users in the consent preferences panel."
+msgstr ""
+
+#: warder-cookie-consent.php:470
+msgid "Explanation of what these cookies do and why they're used."
+msgstr ""
+
+#: warder-cookie-consent.php:479
+msgid "Enabled by default"
+msgstr ""
+
+#: warder-cookie-consent.php:481
+msgid "If checked, this category will be pre-selected when the user sees the banner."
+msgstr ""
+
+#: warder-cookie-consent.php:492
+msgid "Read-only (user cannot change)"
+msgstr ""
+
+#: warder-cookie-consent.php:494
+msgid "If checked, users won't be able to toggle this category off. The \"necessary\" category is always read-only."
+msgstr ""
+
+#: warder-cookie-consent.php:499
+msgid "Cookies in this category"
+msgstr ""
+
+#: warder-cookie-consent.php:505
+msgid "Cookie Name / Pattern"
+msgstr ""
+
+#: warder-cookie-consent.php:506
+msgid "Type"
+msgstr ""
+
+#: warder-cookie-consent.php:507
+msgid "Actions"
+msgstr ""
+
+#: warder-cookie-consent.php:523
+#: warder-cookie-consent.php:608
+msgid "Regular Expression"
+msgstr ""
+
+#: warder-cookie-consent.php:523
+msgid "Exact Match"
+msgstr ""
+
+#: warder-cookie-consent.php:543
+msgid "Are you sure you want to remove this cookie?"
+msgstr ""
+
+#: warder-cookie-consent.php:544
+msgid "Remove"
+msgstr ""
+
+#: warder-cookie-consent.php:552
+msgid "No cookies defined for this category yet."
+msgstr ""
+
+#: warder-cookie-consent.php:557
+msgid "Add Cookie to this Category"
+msgstr ""
+
+#: warder-cookie-consent.php:564
+msgid "No cookie categories found. Default categories will be created when you save settings."
+msgstr ""
+
+#: warder-cookie-consent.php:569
+msgid "Save All Settings"
+msgstr ""
+
+#: warder-cookie-consent.php:574
+#: warder-cookie-consent.php:578
+msgid "Add New Category"
+msgstr ""
+
+#: warder-cookie-consent.php:577
+msgid "New category ID (e.g. marketing)"
+msgstr ""
+
+#: warder-cookie-consent.php:579
+msgid "Common categories: marketing, preferences, functional, etc."
+msgstr ""
+
+#. translators: %s: cookie category title.
+#: warder-cookie-consent.php:589
+#, php-format
+msgid "Add Cookie to \"%s\""
+msgstr ""
+
+#: warder-cookie-consent.php:597
+msgid "Cookie Name/Pattern"
+msgstr ""
+
+#: warder-cookie-consent.php:599
+msgid "e.g., _ga or /^_ga/"
+msgstr ""
+
+#: warder-cookie-consent.php:600
+msgid "Enter a specific cookie name or a pattern to match multiple cookies."
+msgstr ""
+
+#: warder-cookie-consent.php:604
+msgid "Match Type"
+msgstr ""
+
+#: warder-cookie-consent.php:610
+msgid "Check if using a pattern like /^_ga/ to match multiple cookies."
+msgstr ""
+
+#: warder-cookie-consent.php:616
+msgid "Add Cookie"
+msgstr ""
+
+#: warder-cookie-consent.php:617
+msgid "Cancel"
+msgstr ""
+
+#: warder-cookie-consent.php:620
+msgid "Common Cookie Patterns"
+msgstr ""
+
+#. translators: 1: Plugin name, 2: HTML link to settings page.
+#: warder-cookie-consent.php:719
+#, php-format
+msgid "Thank you for installing %1$s! Please configure your settings on the %2$s."
+msgstr ""
+
+#: warder-cookie-consent.php:721
+msgid "settings page"
+msgstr ""
+
+#: warder-cookie-consent.php:793
+msgid "Cookie Preferences"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.3.2
+Stable tag: 1.4.0
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -72,6 +72,14 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 
 == Changelog ==
 
+= 1.4.0 =
+*2026-05-27*
+
+* Fixed: the "Add New Category", "Add Cookie", and "Remove" cookie controls rendered but had no backend handler after an earlier refactor — they now work again
+* Added: restored category/cookie management handlers (add category, add cookie, delete cookie, delete category) consolidated in `warder_handle_admin_actions()`, each with nonce verification and input sanitization
+* Added: "Delete Category" link in each non-necessary category header
+* Added: `Requires at least` and `Requires PHP` headers to the main plugin file
+
 = 1.3.2 =
 *2026-05-27*
 
@@ -132,6 +140,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.0 =
+Restores the category/cookie management buttons (add/remove category and cookie) that were not working, with nonce-protected handlers. Adds minimum WordPress/PHP version headers.
 
 = 1.3.2 =
 WordPress.org compliance fixes: inline script moved to wp_add_inline_script, CSS output sanitized, source code documentation added to readme.

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Added: restored category/cookie management handlers (add category, add cookie, delete cookie, delete category) consolidated in `warder_handle_admin_actions()`, each with nonce verification and input sanitization
 * Added: "Delete Category" link in each non-necessary category header
 * Added: `Requires at least` and `Requires PHP` headers to the main plugin file
+* Changed: wrapped all hardcoded admin settings-page strings in translation/escaping functions (`esc_html_e`, `esc_attr_e`, `esc_html__`, `esc_js`) so admin UI text is translatable and escaped on output
 
 = 1.3.2 =
 *2026-05-27*

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,9 +2,11 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 1.3.2
+ * Version: 1.4.0
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
+ * Requires at least: 5.0
+ * Requires PHP: 8.0
  * Text Domain: warder-cookie-consent
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -187,6 +189,85 @@ jQuery(document).ready(function($) {
 add_action( 'admin_enqueue_scripts', 'warder_enqueue_admin_scripts' );
 
 /**
+ * Processes add/delete actions for cookie categories and cookies on the settings page.
+ *
+ * @param array $options The current merged plugin options.
+ * @return array The options after any add/delete action has been applied.
+ */
+function warder_handle_admin_actions( $options ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return $options;
+	}
+
+	$changed = false;
+
+	// Add a new cookie category.
+	if ( isset( $_POST['warder_add_category'], $_POST['warder_category_nonce'] ) ) {
+		check_admin_referer( 'warder_add_category', 'warder_category_nonce' );
+
+		$new_id = isset( $_POST['new_category_id'] ) ? sanitize_key( wp_unslash( $_POST['new_category_id'] ) ) : '';
+
+		if ( '' !== $new_id && ! isset( $options['cookie_categories'][ $new_id ] ) ) {
+			$options['cookie_categories'][ $new_id ] = array(
+				'title'       => ucfirst( $new_id ),
+				'description' => '',
+				'enabled'     => false,
+				'readonly'    => false,
+				'cookies'     => array(),
+			);
+			$changed                                 = true;
+		}
+	}
+
+	// Add a cookie to an existing category.
+	if ( isset( $_POST['warder_add_cookie'], $_POST['warder_cookie_nonce'] ) ) {
+		check_admin_referer( 'warder_add_cookie', 'warder_cookie_nonce' );
+
+		$category_id = isset( $_POST['category_id'] ) ? sanitize_key( wp_unslash( $_POST['category_id'] ) ) : '';
+		$cookie_name = isset( $_POST['cookie_name'] ) ? sanitize_text_field( wp_unslash( $_POST['cookie_name'] ) ) : '';
+		$is_regex    = isset( $_POST['is_regex'] );
+
+		if ( '' !== $cookie_name && isset( $options['cookie_categories'][ $category_id ] ) ) {
+			$options['cookie_categories'][ $category_id ]['cookies'][] = array(
+				'name'     => $cookie_name,
+				'is_regex' => $is_regex,
+			);
+			$changed = true;
+		}
+	}
+
+	// Delete a cookie category.
+	if ( isset( $_GET['action'] ) && 'delete_category' === sanitize_key( wp_unslash( $_GET['action'] ) ) ) {
+		$category_id = isset( $_GET['category'] ) ? sanitize_key( wp_unslash( $_GET['category'] ) ) : '';
+		$nonce       = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+		if ( wp_verify_nonce( $nonce, 'delete_category_' . $category_id ) && 'necessary' !== $category_id && isset( $options['cookie_categories'][ $category_id ] ) ) {
+			unset( $options['cookie_categories'][ $category_id ] );
+			$changed = true;
+		}
+	}
+
+	// Delete a single cookie from a category.
+	if ( isset( $_GET['action'] ) && 'delete_cookie' === sanitize_key( wp_unslash( $_GET['action'] ) ) ) {
+		$category_id  = isset( $_GET['category'] ) ? sanitize_key( wp_unslash( $_GET['category'] ) ) : '';
+		$cookie_index = isset( $_GET['cookie_index'] ) ? absint( wp_unslash( $_GET['cookie_index'] ) ) : -1;
+		$nonce        = isset( $_GET['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+		if ( $cookie_index >= 0 && wp_verify_nonce( $nonce, 'delete_cookie_' . $category_id . '_' . $cookie_index ) && isset( $options['cookie_categories'][ $category_id ]['cookies'][ $cookie_index ] ) ) {
+			array_splice( $options['cookie_categories'][ $category_id ]['cookies'], $cookie_index, 1 );
+			$changed = true;
+		}
+	}
+
+	if ( $changed ) {
+		update_option( 'warder_options', $options );
+		delete_transient( 'warder_options_cache' );
+	}
+
+	return $options;
+}
+
+/**
  * Renders the plugin settings page in the WordPress admin.
  */
 function warder_render_options_page() {
@@ -208,6 +289,8 @@ function warder_render_options_page() {
 	if ( ! isset( $options['cookie_categories'] ) || ! is_array( $options['cookie_categories'] ) ) {
 		$options['cookie_categories'] = $default_options['cookie_categories'];
 	}
+
+	$options = warder_handle_admin_actions( $options );
 
 	?>
 	<div class="wrap">
@@ -344,7 +427,28 @@ function warder_render_options_page() {
 				foreach ( $options['cookie_categories'] as $category_id => $category ) :
 					?>
 				<div class="warder-category-section" style="margin-bottom: 20px; padding: 15px; background: #f9f9f9; border: 1px solid #ddd;">
-					<h3 style="margin-top: 0;"><?php echo esc_html( $category['title'] ); ?> (<?php echo esc_html( $category_id ); ?>)</h3>
+					<h3 style="margin-top: 0;">
+						<?php echo esc_html( $category['title'] ); ?> (<?php echo esc_html( $category_id ); ?>)
+						<?php if ( 'necessary' !== $category_id ) : ?>
+							<a href="
+							<?php
+							echo esc_url(
+								wp_nonce_url(
+									add_query_arg(
+										array(
+											'page'     => 'warder-cookie-consent',
+											'action'   => 'delete_category',
+											'category' => $category_id,
+										),
+										admin_url( 'options-general.php' )
+									),
+									'delete_category_' . $category_id
+								)
+							);
+							?>
+							" class="button button-small" style="float: right;" onclick="return confirm('<?php echo esc_js( __( 'Delete this entire category and its cookies?', 'warder-cookie-consent' ) ); ?>');"><?php esc_html_e( 'Delete Category', 'warder-cookie-consent' ); ?></a>
+						<?php endif; ?>
+					</h3>
 
 					<table class="form-table">
 						<tr>

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -298,7 +298,7 @@ function warder_render_options_page() {
 
 		<?php if ( $settings_updated ) : ?>
 		<div class="notice notice-success is-dismissible">
-			<p><strong>Settings saved successfully.</strong></p>
+			<p><strong><?php esc_html_e( 'Settings saved successfully.', 'warder-cookie-consent' ); ?></strong></p>
 		</div>
 		<?php endif; ?>
 
@@ -307,120 +307,120 @@ function warder_render_options_page() {
 			<?php settings_fields( 'warder_options_group' ); ?>
 
 			<!-- General Settings Section -->
-			<h2>General Settings</h2>
+			<h2><?php esc_html_e( 'General Settings', 'warder-cookie-consent' ); ?></h2>
 			<table class="form-table">
 				<tr>
-					<th scope="row">Enable Plugin</th>
+					<th scope="row"><?php esc_html_e( 'Enable Plugin', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<label>
 							<input type="checkbox" name="warder_options[enabled]" <?php checked( $options['enabled'], true ); ?> />
-							Display the cookie consent banner on the frontend
+							<?php esc_html_e( 'Display the cookie consent banner on the frontend', 'warder-cookie-consent' ); ?>
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Language</th>
+					<th scope="row"><?php esc_html_e( 'Language', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<select name="warder_options[current_lang]">
-							<option value="en" <?php selected( $options['current_lang'], 'en' ); ?>>English</option>
-							<option value="fr" <?php selected( $options['current_lang'], 'fr' ); ?>>French</option>
-							<option value="de" <?php selected( $options['current_lang'], 'de' ); ?>>German</option>
-							<option value="es" <?php selected( $options['current_lang'], 'es' ); ?>>Spanish</option>
-							<option value="it" <?php selected( $options['current_lang'], 'it' ); ?>>Italian</option>
-							<option value="nl" <?php selected( $options['current_lang'], 'nl' ); ?>>Dutch</option>
+							<option value="en" <?php selected( $options['current_lang'], 'en' ); ?>><?php esc_html_e( 'English', 'warder-cookie-consent' ); ?></option>
+							<option value="fr" <?php selected( $options['current_lang'], 'fr' ); ?>><?php esc_html_e( 'French', 'warder-cookie-consent' ); ?></option>
+							<option value="de" <?php selected( $options['current_lang'], 'de' ); ?>><?php esc_html_e( 'German', 'warder-cookie-consent' ); ?></option>
+							<option value="es" <?php selected( $options['current_lang'], 'es' ); ?>><?php esc_html_e( 'Spanish', 'warder-cookie-consent' ); ?></option>
+							<option value="it" <?php selected( $options['current_lang'], 'it' ); ?>><?php esc_html_e( 'Italian', 'warder-cookie-consent' ); ?></option>
+							<option value="nl" <?php selected( $options['current_lang'], 'nl' ); ?>><?php esc_html_e( 'Dutch', 'warder-cookie-consent' ); ?></option>
 						</select>
-						<p class="description">Default language for the cookie consent banner. For more languages, you'll need to modify the src/index.js file.</p>
+						<p class="description"><?php esc_html_e( "Default language for the cookie consent banner. For more languages, you'll need to modify the src/index.js file.", 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Auto-clear Cookies</th>
+					<th scope="row"><?php esc_html_e( 'Auto-clear Cookies', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<label>
 							<input type="checkbox" name="warder_options[autoclear_cookies]" <?php checked( $options['autoclear_cookies'], true ); ?> />
-							Automatically clear cookies when user rejects them
+							<?php esc_html_e( 'Automatically clear cookies when user rejects them', 'warder-cookie-consent' ); ?>
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Page Scripts</th>
+					<th scope="row"><?php esc_html_e( 'Page Scripts', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<label>
 							<input type="checkbox" name="warder_options[page_scripts]" <?php checked( $options['page_scripts'], true ); ?> />
-							Control script execution based on user consent
+							<?php esc_html_e( 'Control script execution based on user consent', 'warder-cookie-consent' ); ?>
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Preferences Toggle Button</th>
+					<th scope="row"><?php esc_html_e( 'Preferences Toggle Button', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<label>
 							<input type="checkbox" name="warder_options[show_preferences_toggle]" <?php checked( $options['show_preferences_toggle'], true ); ?> />
-							Show a floating button to reopen cookie preferences
+							<?php esc_html_e( 'Show a floating button to reopen cookie preferences', 'warder-cookie-consent' ); ?>
 						</label>
-						<p class="description">Displays a cookie icon button that lets users revisit their consent choices at any time.</p>
+						<p class="description"><?php esc_html_e( 'Displays a cookie icon button that lets users revisit their consent choices at any time.', 'warder-cookie-consent' ); ?></p>
 						<br>
 						<select name="warder_options[preferences_toggle_position]">
-							<option value="bottom-right" <?php selected( $options['preferences_toggle_position'], 'bottom-right' ); ?>>Bottom Right</option>
-							<option value="bottom-left" <?php selected( $options['preferences_toggle_position'], 'bottom-left' ); ?>>Bottom Left</option>
-							<option value="top-right" <?php selected( $options['preferences_toggle_position'], 'top-right' ); ?>>Top Right</option>
-							<option value="top-left" <?php selected( $options['preferences_toggle_position'], 'top-left' ); ?>>Top Left</option>
+							<option value="bottom-right" <?php selected( $options['preferences_toggle_position'], 'bottom-right' ); ?>><?php esc_html_e( 'Bottom Right', 'warder-cookie-consent' ); ?></option>
+							<option value="bottom-left" <?php selected( $options['preferences_toggle_position'], 'bottom-left' ); ?>><?php esc_html_e( 'Bottom Left', 'warder-cookie-consent' ); ?></option>
+							<option value="top-right" <?php selected( $options['preferences_toggle_position'], 'top-right' ); ?>><?php esc_html_e( 'Top Right', 'warder-cookie-consent' ); ?></option>
+							<option value="top-left" <?php selected( $options['preferences_toggle_position'], 'top-left' ); ?>><?php esc_html_e( 'Top Left', 'warder-cookie-consent' ); ?></option>
 						</select>
-						<p class="description">Corner where the floating button appears.</p>
+						<p class="description"><?php esc_html_e( 'Corner where the floating button appears.', 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 			</table>
 
 			<!-- Consent Modal Section -->
-			<h2>Consent Modal</h2>
+			<h2><?php esc_html_e( 'Consent Modal', 'warder-cookie-consent' ); ?></h2>
 			<table class="form-table">
 				<tr>
-					<th scope="row">Title</th>
+					<th scope="row"><?php esc_html_e( 'Title', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<input type="text" name="warder_options[title]" value="<?php echo esc_attr( $options['title'] ); ?>" class="regular-text" />
-						<p class="description">Title displayed in the cookie consent banner.</p>
+						<p class="description"><?php esc_html_e( 'Title displayed in the cookie consent banner.', 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Description</th>
+					<th scope="row"><?php esc_html_e( 'Description', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<textarea name="warder_options[description]" rows="4" class="large-text"><?php echo esc_textarea( $options['description'] ); ?></textarea>
-						<p class="description">Main description explaining cookie usage on your site.</p>
+						<p class="description"><?php esc_html_e( 'Main description explaining cookie usage on your site.', 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Primary Button</th>
+					<th scope="row"><?php esc_html_e( 'Primary Button', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<input type="text" name="warder_options[primary_btn_text]" value="<?php echo esc_attr( $options['primary_btn_text'] ); ?>" class="regular-text" />
 						<select name="warder_options[primary_btn_role]">
-							<option value="accept_all" <?php selected( $options['primary_btn_role'], 'accept_all' ); ?>>Accept All</option>
-							<option value="accept_selected" <?php selected( $options['primary_btn_role'], 'accept_selected' ); ?>>Accept Selected</option>
+							<option value="accept_all" <?php selected( $options['primary_btn_role'], 'accept_all' ); ?>><?php esc_html_e( 'Accept All', 'warder-cookie-consent' ); ?></option>
+							<option value="accept_selected" <?php selected( $options['primary_btn_role'], 'accept_selected' ); ?>><?php esc_html_e( 'Accept Selected', 'warder-cookie-consent' ); ?></option>
 						</select>
-						<p class="description">Primary action button for the consent banner.</p>
+						<p class="description"><?php esc_html_e( 'Primary action button for the consent banner.', 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Secondary Button</th>
+					<th scope="row"><?php esc_html_e( 'Secondary Button', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<input type="text" name="warder_options[secondary_btn_text]" value="<?php echo esc_attr( $options['secondary_btn_text'] ); ?>" class="regular-text" />
 						<select name="warder_options[secondary_btn_role]">
-							<option value="accept_necessary" <?php selected( $options['secondary_btn_role'], 'accept_necessary' ); ?>>Accept Necessary</option>
-							<option value="settings" <?php selected( $options['secondary_btn_role'], 'settings' ); ?>>Settings</option>
+							<option value="accept_necessary" <?php selected( $options['secondary_btn_role'], 'accept_necessary' ); ?>><?php esc_html_e( 'Accept Necessary', 'warder-cookie-consent' ); ?></option>
+							<option value="settings" <?php selected( $options['secondary_btn_role'], 'settings' ); ?>><?php esc_html_e( 'Settings', 'warder-cookie-consent' ); ?></option>
 						</select>
-						<p class="description">Secondary action button for the consent banner.</p>
+						<p class="description"><?php esc_html_e( 'Secondary action button for the consent banner.', 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row">Privacy Policy URL</th>
+					<th scope="row"><?php esc_html_e( 'Privacy Policy URL', 'warder-cookie-consent' ); ?></th>
 					<td>
 						<input type="text" name="warder_options[privacy_policy_url]" value="<?php echo esc_attr( $options['privacy_policy_url'] ); ?>" class="regular-text" />
-						<p class="description">Link to your privacy policy page. Default: #privacy-policy</p>
+						<p class="description"><?php esc_html_e( 'Link to your privacy policy page. Default: #privacy-policy', 'warder-cookie-consent' ); ?></p>
 					</td>
 				</tr>
 			</table>
 
 			<!-- Cookie Categories Section -->
-			<h2>Cookie Categories</h2>
-			<p>Configure cookie categories and specific cookies to be blocked until consent is given.</p>
+			<h2><?php esc_html_e( 'Cookie Categories', 'warder-cookie-consent' ); ?></h2>
+			<p><?php esc_html_e( 'Configure cookie categories and specific cookies to be blocked until consent is given.', 'warder-cookie-consent' ); ?></p>
 
 			<?php
 			if ( isset( $options['cookie_categories'] ) && is_array( $options['cookie_categories'] ) ) {
@@ -452,33 +452,33 @@ function warder_render_options_page() {
 
 					<table class="form-table">
 						<tr>
-							<th scope="row">Title</th>
+							<th scope="row"><?php esc_html_e( 'Title', 'warder-cookie-consent' ); ?></th>
 							<td>
 								<input type="text"
 										name="warder_options[cookie_categories][<?php echo esc_attr( $category_id ); ?>][title]"
 										value="<?php echo esc_attr( $category['title'] ); ?>"
 										class="regular-text warder-category-title-field"
 										id="warder-category-<?php echo esc_attr( $category_id ); ?>-title" />
-								<p class="description">The name displayed to users in the consent preferences panel.</p>
+								<p class="description"><?php esc_html_e( 'The name displayed to users in the consent preferences panel.', 'warder-cookie-consent' ); ?></p>
 							</td>
 						</tr>
 						<tr>
-							<th scope="row">Description</th>
+							<th scope="row"><?php esc_html_e( 'Description', 'warder-cookie-consent' ); ?></th>
 							<td>
 								<textarea name="warder_options[cookie_categories][<?php echo esc_attr( $category_id ); ?>][description]"
 									rows="2" class="large-text"><?php echo esc_textarea( $category['description'] ); ?></textarea>
-								<p class="description">Explanation of what these cookies do and why they're used.</p>
+								<p class="description"><?php esc_html_e( "Explanation of what these cookies do and why they're used.", 'warder-cookie-consent' ); ?></p>
 							</td>
 						</tr>
 						<tr>
-							<th scope="row">Settings</th>
+							<th scope="row"><?php esc_html_e( 'Settings', 'warder-cookie-consent' ); ?></th>
 							<td>
 								<label>
 									<input type="checkbox" name="warder_options[cookie_categories][<?php echo esc_attr( $category_id ); ?>][enabled]"
 										<?php checked( $category['enabled'], true ); ?> />
-									Enabled by default
+									<?php esc_html_e( 'Enabled by default', 'warder-cookie-consent' ); ?>
 								</label>
-								<p class="description">If checked, this category will be pre-selected when the user sees the banner.</p>
+								<p class="description"><?php esc_html_e( 'If checked, this category will be pre-selected when the user sees the banner.', 'warder-cookie-consent' ); ?></p>
 								<br>
 								<label>
 									<input type="checkbox" name="warder_options[cookie_categories][<?php echo esc_attr( $category_id ); ?>][readonly]"
@@ -489,22 +489,22 @@ function warder_render_options_page() {
 										}
 										?>
 										/>
-									Read-only (user cannot change)
+									<?php esc_html_e( 'Read-only (user cannot change)', 'warder-cookie-consent' ); ?>
 								</label>
-								<p class="description">If checked, users won't be able to toggle this category off. The "necessary" category is always read-only.</p>
+								<p class="description"><?php esc_html_e( 'If checked, users won\'t be able to toggle this category off. The "necessary" category is always read-only.', 'warder-cookie-consent' ); ?></p>
 							</td>
 						</tr>
 					</table>
 
-					<h4>Cookies in this category</h4>
+					<h4><?php esc_html_e( 'Cookies in this category', 'warder-cookie-consent' ); ?></h4>
 
 					<?php if ( ! empty( $category['cookies'] ) ) : ?>
 						<table class="widefat striped">
 							<thead>
 								<tr>
-									<th>Cookie Name / Pattern</th>
-									<th>Type</th>
-									<th>Actions</th>
+									<th><?php esc_html_e( 'Cookie Name / Pattern', 'warder-cookie-consent' ); ?></th>
+									<th><?php esc_html_e( 'Type', 'warder-cookie-consent' ); ?></th>
+									<th><?php esc_html_e( 'Actions', 'warder-cookie-consent' ); ?></th>
 								</tr>
 							</thead>
 							<tbody>
@@ -540,8 +540,8 @@ function warder_render_options_page() {
 												)
 											);
 											?>
-											" class="button button-small" onclick="return confirm('Are you sure you want to remove this cookie?');">
-												Remove
+											" class="button button-small" onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to remove this cookie?', 'warder-cookie-consent' ) ); ?>');">
+												<?php esc_html_e( 'Remove', 'warder-cookie-consent' ); ?>
 											</a>
 										</td>
 									</tr>
@@ -549,70 +549,75 @@ function warder_render_options_page() {
 							</tbody>
 						</table>
 					<?php else : ?>
-						<p>No cookies defined for this category yet.</p>
+						<p><?php esc_html_e( 'No cookies defined for this category yet.', 'warder-cookie-consent' ); ?></p>
 					<?php endif; ?>
 
 					<div style="margin-top: 10px;">
 						<button type="button" class="button show-add-cookie-form" data-category="<?php echo esc_attr( $category_id ); ?>">
-							Add Cookie to this Category
+							<?php esc_html_e( 'Add Cookie to this Category', 'warder-cookie-consent' ); ?>
 						</button>
 					</div>
 				</div>
 					<?php
 				endforeach;
 			} else {
-				echo '<p>No cookie categories found. Default categories will be created when you save settings.</p>';
+				echo '<p>' . esc_html__( 'No cookie categories found. Default categories will be created when you save settings.', 'warder-cookie-consent' ) . '</p>';
 			}
 			?>
 
 			<!-- Submit button for main settings -->
-			<?php submit_button( 'Save All Settings', 'primary', 'submit', false ); ?>
+			<?php submit_button( __( 'Save All Settings', 'warder-cookie-consent' ), 'primary', 'submit', false ); ?>
 		</form>
 
 		<!-- SEPARATE FORMS FOR ADDING COOKIES AND CATEGORIES -->
 		<div style="margin: 20px 0; padding: 15px; background: #f5f5f5; border: 1px solid #ddd;">
-			<h3>Add New Category</h3>
+			<h3><?php esc_html_e( 'Add New Category', 'warder-cookie-consent' ); ?></h3>
 			<form method="post" action="" id="warder-add-category-form">
 				<?php wp_nonce_field( 'warder_add_category', 'warder_category_nonce' ); ?>
-				<input type="text" name="new_category_id" placeholder="New category ID (e.g. marketing)" class="regular-text" required />
-				<input type="submit" name="warder_add_category" value="Add New Category" class="button button-secondary" />
-				<p class="description">Common categories: marketing, preferences, functional, etc.</p>
+				<input type="text" name="new_category_id" placeholder="<?php esc_attr_e( 'New category ID (e.g. marketing)', 'warder-cookie-consent' ); ?>" class="regular-text" required />
+				<input type="submit" name="warder_add_category" value="<?php esc_attr_e( 'Add New Category', 'warder-cookie-consent' ); ?>" class="button button-secondary" />
+				<p class="description"><?php esc_html_e( 'Common categories: marketing, preferences, functional, etc.', 'warder-cookie-consent' ); ?></p>
 			</form>
 		</div>
 
 		<?php foreach ( $options['cookie_categories'] as $category_id => $category ) : ?>
 		<div class="warder-add-cookie-form-container" style="margin: 10px 0; display: none;" id="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>">
 			<div style="padding: 15px; background: #f5f5f5; border: 1px solid #ddd;">
-				<h4>Add Cookie to "<?php echo esc_html( $category['title'] ); ?>"</h4>
+				<h4>
+					<?php
+					/* translators: %s: cookie category title. */
+					printf( esc_html__( 'Add Cookie to "%s"', 'warder-cookie-consent' ), esc_html( $category['title'] ) );
+					?>
+				</h4>
 				<form method="post" action="" class="scc-add-cookie-form">
 					<?php wp_nonce_field( 'warder_add_cookie', 'warder_cookie_nonce' ); ?>
 					<input type="hidden" name="category_id" value="<?php echo esc_attr( $category_id ); ?>" />
 					<table class="form-table">
 						<tr>
-							<th scope="row">Cookie Name/Pattern</th>
+							<th scope="row"><?php esc_html_e( 'Cookie Name/Pattern', 'warder-cookie-consent' ); ?></th>
 							<td>
-								<input type="text" name="cookie_name" placeholder="e.g., _ga or /^_ga/" class="regular-text" required />
-								<p class="description">Enter a specific cookie name or a pattern to match multiple cookies.</p>
+								<input type="text" name="cookie_name" placeholder="<?php esc_attr_e( 'e.g., _ga or /^_ga/', 'warder-cookie-consent' ); ?>" class="regular-text" required />
+								<p class="description"><?php esc_html_e( 'Enter a specific cookie name or a pattern to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
 							</td>
 						</tr>
 						<tr>
-							<th scope="row">Match Type</th>
+							<th scope="row"><?php esc_html_e( 'Match Type', 'warder-cookie-consent' ); ?></th>
 							<td>
 								<label>
 									<input type="checkbox" name="is_regex" />
-									Regular Expression
+									<?php esc_html_e( 'Regular Expression', 'warder-cookie-consent' ); ?>
 								</label>
-								<p class="description">Check if using a pattern like /^_ga/ to match multiple cookies.</p>
+								<p class="description"><?php esc_html_e( 'Check if using a pattern like /^_ga/ to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
 							</td>
 						</tr>
 					</table>
 
 					<p>
-						<input type="submit" name="warder_add_cookie" value="Add Cookie" class="button button-primary" />
-						<button type="button" class="button button-secondary cancel-add-cookie">Cancel</button>
+						<input type="submit" name="warder_add_cookie" value="<?php esc_attr_e( 'Add Cookie', 'warder-cookie-consent' ); ?>" class="button button-primary" />
+						<button type="button" class="button button-secondary cancel-add-cookie"><?php esc_html_e( 'Cancel', 'warder-cookie-consent' ); ?></button>
 					</p>
 
-					<h5>Common Cookie Patterns</h5>
+					<h5><?php esc_html_e( 'Common Cookie Patterns', 'warder-cookie-consent' ); ?></h5>
 					<ul class="cookie-pattern-examples">
 						<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
 						<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
@@ -713,7 +718,7 @@ function warder_admin_notices() {
 		/* translators: 1: Plugin name, 2: HTML link to settings page. */
 		esc_html__( 'Thank you for installing %1$s! Please configure your settings on the %2$s.', 'warder-cookie-consent' ),
 		esc_html( $plugin_name ),
-		'<a href="' . esc_url( admin_url( 'options-general.php?page=warder-cookie-consent' ) ) . '">settings page</a>'
+		'<a href="' . esc_url( admin_url( 'options-general.php?page=warder-cookie-consent' ) ) . '">' . esc_html__( 'settings page', 'warder-cookie-consent' ) . '</a>'
 	) . '</p>';
 	echo '</div>';
 }
@@ -810,6 +815,6 @@ function warder_render_category_title_field( $category_id, $title ) {
 			value="<?php echo esc_attr( $title ); ?>"
 			class="regular-text warder-category-title-field"
 			data-category-id="<?php echo esc_attr( $category_id ); ?>" />
-	<p class="description">The name displayed to users in the consent preferences panel.</p>
+	<p class="description"><?php esc_html_e( 'The name displayed to users in the consent preferences panel.', 'warder-cookie-consent' ); ?></p>
 	<?php
 }


### PR DESCRIPTION
This pull request introduces full internationalization (i18n) support for the Warder Cookie Consent plugin's admin settings page, making all user-facing strings translatable and properly escaped in accordance with WordPress coding standards. A `.pot` translation template has been generated and committed to the `languages/` directory, providing translators with the canonical source file required to produce locale-specific translations. In addition, category and cookie management AJAX handlers that had been inadvertently removed were restored in `warder-cookie-consent.php`, along with version headers that align the file metadata with the current release. The changelog and readme have been updated to reflect these additions.

**Internationalization and Localization:**
- All admin settings-page strings in `warder-cookie-consent.php` are now wrapped in WordPress translation and escaping functions (`__()`, `esc_html__()`, `esc_html_e()`, etc.), ensuring output is both translatable and safe against XSS.
- A `languages/warder-cookie-consent.pot` Portable Object Template file has been added, serving as the authoritative source for translators to create language-specific `.po`/`.mo` files.

**Bug Fixes and File Integrity:**
- Category and cookie management request handlers were restored after being unintentionally dropped in a prior commit, ensuring the admin UI can properly save and update consent category and cookie configurations.
- PHP file version headers were added to `warder-cookie-consent.php` to maintain consistency with WordPress plugin conventions and facilitate version-aware cache busting.

**Documentation:**
- `CHANGELOG.md` and `readme.txt` have been updated to document the i18n additions and the handler restoration, keeping release notes accurate for plugin reviewers and end users.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/fix/restore-category-cookie-handlers/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/fix/restore-category-cookie-handlers/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/fix/restore-category-cookie-handlers/warder-cookie-consent.php) (Modified)
- [`languages/warder-cookie-consent.pot`](https://github.com/imagewize/warder-cookie-consent/blob/fix/restore-category-cookie-handlers/languages/warder-cookie-consent.pot) (Added)