### PR TITLE
Fix/wp Review Sanitization

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,12 +10,9 @@
 phpcs.xml
 composer.json
 composer.lock
-package.json
 package-lock.json
-webpack.config.js
 
-# Source files (bundled output is in dist/)
-src/*
+# Third-party dependency directories (src/ and webpack.config.js ship so reviewers can read the source)
 node_modules/*
 vendor/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [1.4.2] - 2026-05-28
+
+### Fixed
+- `register_setting()` updated to array format with explicit `sanitize_callback` key — satisfies WordPress.org guideline requiring formal sanitize_callback declaration
+- `privacy_policy_url` now sanitized with `esc_url_raw()` instead of `sanitize_text_field()` — correct sanitizer for URL values
+
+### Changed
+- `.distignore` updated to ship `src/`, `webpack.config.js`, and `package.json` in the WordPress.org build — satisfies the human-readable source code requirement (guideline §4); `node_modules/` and `vendor/` remain excluded
+
 ## [1.4.1] - 2026-05-27
 
 ### Changed

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -71,6 +71,13 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 3. Cookie category management interface
 
 == Changelog ==
+
+= 1.4.2 =
+*2026-05-28*
+
+* Fixed: `register_setting()` updated to array format with explicit `sanitize_callback` key as required by WordPress.org guidelines
+* Fixed: `privacy_policy_url` now sanitized with `esc_url_raw()` instead of `sanitize_text_field()` for proper URL sanitization
+* Changed: `.distignore` updated to include `src/`, `webpack.config.js`, and `package.json` in the WordPress.org build so the human-readable source is available to reviewers (guideline §4)
 
 = 1.4.1 =
 *2026-05-27*
@@ -146,6 +153,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.4.2 =
+WordPress.org compliance fixes: register_setting() uses array format with sanitize_callback, privacy_policy_url uses esc_url_raw(), and src/ ships in the build for human-readable source access.
 
 = 1.4.1 =
 Replaces the 10up/wpcs-action CI workflow with local PHPCS, adding strict i18n (text domain) and output escaping checks on pull requests.

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 1.4.1
+ * Version: 1.4.2
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -20,7 +20,14 @@ defined( 'ABSPATH' ) || exit;
  * Registers plugin settings and adds default options on first activation.
  */
 function warder_register_settings() {
-	register_setting( 'warder_options_group', 'warder_options', 'warder_validate_options' );
+	register_setting(
+		'warder_options_group',
+		'warder_options',
+		array(
+			'type'              => 'array',
+			'sanitize_callback' => 'warder_validate_options',
+		)
+	);
 
 	if ( false === get_option( 'warder_options' ) ) {
 		add_option( 'warder_options', warder_get_default_options() );
@@ -106,7 +113,7 @@ function warder_validate_options( $input ) {
 	$valid['secondary_btn_text']          = sanitize_text_field( $input['secondary_btn_text'] );
 	$valid['secondary_btn_role']          = in_array( $input['secondary_btn_role'], array( 'accept_necessary', 'settings' ), true )
 		? $input['secondary_btn_role'] : 'accept_necessary';
-	$valid['privacy_policy_url']          = sanitize_text_field( $input['privacy_policy_url'] );
+	$valid['privacy_policy_url']          = esc_url_raw( $input['privacy_policy_url'] );
 	$valid['show_preferences_toggle']     = isset( $input['show_preferences_toggle'] ) ? true : false;
 	$valid['preferences_toggle_position'] = in_array( $input['preferences_toggle_position'], array( 'bottom-right', 'bottom-left', 'top-right', 'top-left' ), true )
 		? $input['preferences_toggle_position'] : 'bottom-right';


### PR DESCRIPTION
This release addresses two distinct correctness issues surfaced during review of the WordPress.org submission pipeline. The PHP sanitization fix ensures URL-typed settings fields are validated with `esc_url_raw()` and that `register_setting()` uses the recommended array form with an explicit sanitize callback, bringing the plugin into conformance with WordPress coding standards and the Plugin Review Team's expectations. The build configuration fix restores `src/`, `webpack.config.js`, and `package.json` to the WP.org distribution package by removing incorrect `.distignore` exclusions — these files are required for contributors to rebuild the JavaScript bundle from source. Both fixes are documented in the v1.4.2 changelog entries across `CHANGELOG.md` and `readme.txt`.

**Sanitization and Settings Registration:**
- Replaced the bare string argument to `register_setting()` with the array form, allowing an explicit `sanitize_callback` to be specified rather than relying on implicit behavior.
- Applied `esc_url_raw()` to the URL settings field during sanitization, replacing a less appropriate sanitizer and ensuring the stored value is a clean, unencoded URL safe for server-side use.

**Build Distribution (`distignore`):**
- Removed `src/`, `webpack.config.js`, and `package.json` from `.distignore` so the WP.org SVN package includes the full source tree needed to reproduce the compiled bundle.
- Previously these exclusions caused the distributed plugin to ship only the compiled `dist/` output with no rebuild path, which is contrary to open-source transparency expectations for WP.org-hosted plugins.

**Documentation:**
- Added v1.4.2 entries to both `CHANGELOG.md` and `readme.txt` describing the sanitization improvements and the `.distignore` correction.

**Files Changed:**

- [`.distignore`](https://github.com/imagewize/warder-cookie-consent/blob/fix/wp-review-sanitization/.distignore) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/fix/wp-review-sanitization/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/fix/wp-review-sanitization/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/fix/wp-review-sanitization/warder-cookie-consent.php) (Modified)