### PR TITLE
Cookie Field Below Add Cookie To Cat Btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Warder Cookie Consent are documented here.
 
 ### Fixed
 - Add Cookie form now appears directly below the "Add Cookie to this Category" button instead of at the bottom of the page (below Save All Settings and Add New Category). Moved the `warder-add-cookie-form-container` divs from the end of `warder_render_options_page()` into each category section, immediately after the show-add-cookie-form button
+- Add Cookie submission was silently being dropped because moving the form into the category section nested it inside the main `<form action="options.php">` — browsers discard nested `<form>` tags, so the click submitted the outer settings form instead. The actual `<form id="warder-add-cookie-form-<id>">` element now lives outside the main settings form; the visible cookie name / regex / submit inputs reference it via the HTML5 `form="..."` attribute
 
 ## [1.5.0] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [1.5.1] - 2026-05-28
+
+### Fixed
+- Add Cookie form now appears directly below the "Add Cookie to this Category" button instead of at the bottom of the page (below Save All Settings and Add New Category). Moved the `warder-add-cookie-form-container` divs from the end of `warder_render_options_page()` into each category section, immediately after the show-add-cookie-form button
+
 ## [1.5.0] - 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "1.0.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imwz-cookie-consent",
-      "version": "1.0.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "vanilla-cookieconsent": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 *2026-05-28*
 
 * Fixed: Add Cookie form now appears directly below the "Add Cookie to this Category" button instead of at the bottom of the page (below Save All Settings and Add New Category)
+* Fixed: Add Cookie submissions were silently dropped because the relocated form ended up nested inside the main settings form, which browsers reject. The actual form element now lives outside the main settings form and the visible inputs reference it via the HTML5 `form` attribute
 
 = 1.5.0 =
 *2026-05-28*
@@ -165,7 +166,7 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 == Upgrade Notice ==
 
 = 1.5.1 =
-Fixes Add Cookie form positioning — now appears directly below the category button instead of at the bottom of the settings page.
+Fixes Add Cookie form positioning so it appears directly below the category button, and fixes a regression where submitting that form silently failed (nested form was being discarded by the browser).
 
 = 1.5.0 =
 Adds Matomo cookie patterns to the default analytics category so new installs manage Matomo cookies out of the box.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -71,6 +71,11 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 3. Cookie category management interface
 
 == Changelog ==
+
+= 1.5.1 =
+*2026-05-28*
+
+* Fixed: Add Cookie form now appears directly below the "Add Cookie to this Category" button instead of at the bottom of the page (below Save All Settings and Add New Category)
 
 = 1.5.0 =
 *2026-05-28*
@@ -158,6 +163,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 1.5.1 =
+Fixes Add Cookie form positioning — now appears directly below the category button instead of at the bottom of the settings page.
 
 = 1.5.0 =
 Adds Matomo cookie patterns to the default analytics category so new installs manage Matomo cookies out of the box.

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -188,7 +188,7 @@ function warder_enqueue_admin_scripts( $hook ) {
 jQuery(document).ready(function($) {
 	$(".show-add-cookie-form").on("click", function() {
 		var categoryId = $(this).data("category");
-		$("#warder-add-cookie-form-" + categoryId).show();
+		$("#warder-add-cookie-container-" + categoryId).show();
 	});
 	$(".cancel-add-cookie").on("click", function(e) {
 		e.preventDefault();
@@ -573,8 +573,9 @@ function warder_render_options_page() {
 						</button>
 					</div>
 
-					<!-- Add Cookie Form Container -->
-					<div class="warder-add-cookie-form-container" style="margin: 10px 0; display: none;" id="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>">
+					<!-- Add Cookie Form Container (the actual <form> lives outside the main settings form;
+						 inputs reference it via the HTML5 `form` attribute so they aren't nested). -->
+					<div class="warder-add-cookie-form-container" style="margin: 10px 0; display: none;" id="warder-add-cookie-container-<?php echo esc_attr( $category_id ); ?>">
 						<div style="padding: 15px; background: #f5f5f5; border: 1px solid #ddd;">
 							<h4>
 								<?php
@@ -582,41 +583,37 @@ function warder_render_options_page() {
 								printf( esc_html__( 'Add Cookie to "%s"', 'warder-cookie-consent' ), esc_html( $category['title'] ) );
 								?>
 							</h4>
-							<form method="post" action="" class="scc-add-cookie-form">
-								<?php wp_nonce_field( 'warder_add_cookie', 'warder_cookie_nonce' ); ?>
-								<input type="hidden" name="category_id" value="<?php echo esc_attr( $category_id ); ?>" />
-								<table class="form-table">
-									<tr>
-										<th scope="row"><?php esc_html_e( 'Cookie Name/Pattern', 'warder-cookie-consent' ); ?></th>
-										<td>
-											<input type="text" name="cookie_name" placeholder="<?php esc_attr_e( 'e.g., _ga or /^_ga/', 'warder-cookie-consent' ); ?>" class="regular-text" required />
-											<p class="description"><?php esc_html_e( 'Enter a specific cookie name or a pattern to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
-										</td>
-									</tr>
-									<tr>
-										<th scope="row"><?php esc_html_e( 'Match Type', 'warder-cookie-consent' ); ?></th>
-										<td>
-											<label>
-												<input type="checkbox" name="is_regex" />
-												<?php esc_html_e( 'Regular Expression', 'warder-cookie-consent' ); ?>
-											</label>
-											<p class="description"><?php esc_html_e( 'Check if using a pattern like /^_ga/ to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
-										</td>
-									</tr>
-								</table>
+							<table class="form-table">
+								<tr>
+									<th scope="row"><?php esc_html_e( 'Cookie Name/Pattern', 'warder-cookie-consent' ); ?></th>
+									<td>
+										<input type="text" name="cookie_name" form="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>" placeholder="<?php esc_attr_e( 'e.g., _ga or /^_ga/', 'warder-cookie-consent' ); ?>" class="regular-text" required />
+										<p class="description"><?php esc_html_e( 'Enter a specific cookie name or a pattern to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
+									</td>
+								</tr>
+								<tr>
+									<th scope="row"><?php esc_html_e( 'Match Type', 'warder-cookie-consent' ); ?></th>
+									<td>
+										<label>
+											<input type="checkbox" name="is_regex" form="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>" />
+											<?php esc_html_e( 'Regular Expression', 'warder-cookie-consent' ); ?>
+										</label>
+										<p class="description"><?php esc_html_e( 'Check if using a pattern like /^_ga/ to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
+									</td>
+								</tr>
+							</table>
 
-								<p>
-									<input type="submit" name="warder_add_cookie" value="<?php esc_attr_e( 'Add Cookie', 'warder-cookie-consent' ); ?>" class="button button-primary" />
-									<button type="button" class="button button-secondary cancel-add-cookie"><?php esc_html_e( 'Cancel', 'warder-cookie-consent' ); ?></button>
-								</p>
+							<p>
+								<input type="submit" name="warder_add_cookie" form="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>" value="<?php esc_attr_e( 'Add Cookie', 'warder-cookie-consent' ); ?>" class="button button-primary" />
+								<button type="button" class="button button-secondary cancel-add-cookie"><?php esc_html_e( 'Cancel', 'warder-cookie-consent' ); ?></button>
+							</p>
 
-								<h5><?php esc_html_e( 'Common Cookie Patterns', 'warder-cookie-consent' ); ?></h5>
-								<ul class="cookie-pattern-examples">
-									<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
-									<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
-									<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code></li>
-								</ul>
-							</form>
+							<h5><?php esc_html_e( 'Common Cookie Patterns', 'warder-cookie-consent' ); ?></h5>
+							<ul class="cookie-pattern-examples">
+								<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
+								<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
+								<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code></li>
+							</ul>
 						</div>
 					</div>
 				</div>
@@ -630,6 +627,21 @@ function warder_render_options_page() {
 			<!-- Submit button for main settings -->
 			<?php submit_button( __( 'Save All Settings', 'warder-cookie-consent' ), 'primary', 'submit', false ); ?>
 		</form>
+
+		<?php
+		// Out-of-DOM Add Cookie forms — one per category. The visible inputs above use
+		// form="warder-add-cookie-form-<id>" to submit here, avoiding nested forms.
+		if ( isset( $options['cookie_categories'] ) && is_array( $options['cookie_categories'] ) ) :
+			foreach ( array_keys( $options['cookie_categories'] ) as $form_category_id ) :
+				?>
+				<form method="post" action="" id="warder-add-cookie-form-<?php echo esc_attr( $form_category_id ); ?>" style="display:none;">
+					<?php wp_nonce_field( 'warder_add_cookie', 'warder_cookie_nonce' ); ?>
+					<input type="hidden" name="category_id" value="<?php echo esc_attr( $form_category_id ); ?>" />
+				</form>
+				<?php
+			endforeach;
+		endif;
+		?>
 
 		<!-- SEPARATE FORMS FOR ADDING COOKIES AND CATEGORIES -->
 		<div style="margin: 20px 0; padding: 15px; background: #f5f5f5; border: 1px solid #ddd;">

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -613,6 +613,7 @@ function warder_render_options_page() {
 								<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
 								<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
 								<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code></li>
+								<li><strong>Matomo:</strong> <code>/^_pk_/</code>, <code>/^mtm_/</code></li>
 							</ul>
 						</div>
 					</div>

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -572,6 +572,53 @@ function warder_render_options_page() {
 							<?php esc_html_e( 'Add Cookie to this Category', 'warder-cookie-consent' ); ?>
 						</button>
 					</div>
+
+					<!-- Add Cookie Form Container -->
+					<div class="warder-add-cookie-form-container" style="margin: 10px 0; display: none;" id="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>">
+						<div style="padding: 15px; background: #f5f5f5; border: 1px solid #ddd;">
+							<h4>
+								<?php
+								/* translators: %s: cookie category title. */
+								printf( esc_html__( 'Add Cookie to "%s"', 'warder-cookie-consent' ), esc_html( $category['title'] ) );
+								?>
+							</h4>
+							<form method="post" action="" class="scc-add-cookie-form">
+								<?php wp_nonce_field( 'warder_add_cookie', 'warder_cookie_nonce' ); ?>
+								<input type="hidden" name="category_id" value="<?php echo esc_attr( $category_id ); ?>" />
+								<table class="form-table">
+									<tr>
+										<th scope="row"><?php esc_html_e( 'Cookie Name/Pattern', 'warder-cookie-consent' ); ?></th>
+										<td>
+											<input type="text" name="cookie_name" placeholder="<?php esc_attr_e( 'e.g., _ga or /^_ga/', 'warder-cookie-consent' ); ?>" class="regular-text" required />
+											<p class="description"><?php esc_html_e( 'Enter a specific cookie name or a pattern to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
+										</td>
+									</tr>
+									<tr>
+										<th scope="row"><?php esc_html_e( 'Match Type', 'warder-cookie-consent' ); ?></th>
+										<td>
+											<label>
+												<input type="checkbox" name="is_regex" />
+												<?php esc_html_e( 'Regular Expression', 'warder-cookie-consent' ); ?>
+											</label>
+											<p class="description"><?php esc_html_e( 'Check if using a pattern like /^_ga/ to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
+										</td>
+									</tr>
+								</table>
+
+								<p>
+									<input type="submit" name="warder_add_cookie" value="<?php esc_attr_e( 'Add Cookie', 'warder-cookie-consent' ); ?>" class="button button-primary" />
+									<button type="button" class="button button-secondary cancel-add-cookie"><?php esc_html_e( 'Cancel', 'warder-cookie-consent' ); ?></button>
+								</p>
+
+								<h5><?php esc_html_e( 'Common Cookie Patterns', 'warder-cookie-consent' ); ?></h5>
+								<ul class="cookie-pattern-examples">
+									<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
+									<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
+									<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code></li>
+								</ul>
+							</form>
+						</div>
+					</div>
 				</div>
 					<?php
 				endforeach;
@@ -594,54 +641,6 @@ function warder_render_options_page() {
 				<p class="description"><?php esc_html_e( 'Common categories: marketing, preferences, functional, etc.', 'warder-cookie-consent' ); ?></p>
 			</form>
 		</div>
-
-		<?php foreach ( $options['cookie_categories'] as $category_id => $category ) : ?>
-		<div class="warder-add-cookie-form-container" style="margin: 10px 0; display: none;" id="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>">
-			<div style="padding: 15px; background: #f5f5f5; border: 1px solid #ddd;">
-				<h4>
-					<?php
-					/* translators: %s: cookie category title. */
-					printf( esc_html__( 'Add Cookie to "%s"', 'warder-cookie-consent' ), esc_html( $category['title'] ) );
-					?>
-				</h4>
-				<form method="post" action="" class="scc-add-cookie-form">
-					<?php wp_nonce_field( 'warder_add_cookie', 'warder_cookie_nonce' ); ?>
-					<input type="hidden" name="category_id" value="<?php echo esc_attr( $category_id ); ?>" />
-					<table class="form-table">
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Cookie Name/Pattern', 'warder-cookie-consent' ); ?></th>
-							<td>
-								<input type="text" name="cookie_name" placeholder="<?php esc_attr_e( 'e.g., _ga or /^_ga/', 'warder-cookie-consent' ); ?>" class="regular-text" required />
-								<p class="description"><?php esc_html_e( 'Enter a specific cookie name or a pattern to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
-							</td>
-						</tr>
-						<tr>
-							<th scope="row"><?php esc_html_e( 'Match Type', 'warder-cookie-consent' ); ?></th>
-							<td>
-								<label>
-									<input type="checkbox" name="is_regex" />
-									<?php esc_html_e( 'Regular Expression', 'warder-cookie-consent' ); ?>
-								</label>
-								<p class="description"><?php esc_html_e( 'Check if using a pattern like /^_ga/ to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
-							</td>
-						</tr>
-					</table>
-
-					<p>
-						<input type="submit" name="warder_add_cookie" value="<?php esc_attr_e( 'Add Cookie', 'warder-cookie-consent' ); ?>" class="button button-primary" />
-						<button type="button" class="button button-secondary cancel-add-cookie"><?php esc_html_e( 'Cancel', 'warder-cookie-consent' ); ?></button>
-					</p>
-
-					<h5><?php esc_html_e( 'Common Cookie Patterns', 'warder-cookie-consent' ); ?></h5>
-					<ul class="cookie-pattern-examples">
-						<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
-						<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
-						<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code></li>
-					</ul>
-				</form>
-			</div>
-		</div>
-		<?php endforeach; ?>
 	</div>
 
 	<?php

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -598,7 +598,11 @@ function warder_render_options_page() {
 											<input type="checkbox" name="is_regex" form="warder-add-cookie-form-<?php echo esc_attr( $category_id ); ?>" />
 											<?php esc_html_e( 'Regular Expression', 'warder-cookie-consent' ); ?>
 										</label>
-										<p class="description"><?php esc_html_e( 'Check if using a pattern like /^_ga/ to match multiple cookies.', 'warder-cookie-consent' ); ?></p>
+										<p class="description">
+											<?php esc_html_e( 'Leave unchecked for exact cookie names (e.g. _gid).', 'warder-cookie-consent' ); ?>
+											<br />
+											<?php esc_html_e( 'Tick this and wrap the value in /slashes/ to match multiple cookies with a pattern (e.g. /^_ga/).', 'warder-cookie-consent' ); ?>
+										</p>
 									</td>
 								</tr>
 							</table>
@@ -610,10 +614,10 @@ function warder_render_options_page() {
 
 							<h5><?php esc_html_e( 'Common Cookie Patterns', 'warder-cookie-consent' ); ?></h5>
 							<ul class="cookie-pattern-examples">
-								<li><strong>Google Analytics:</strong> <code>/^_ga/</code>, <code>_gid</code>, <code>_gat</code></li>
-								<li><strong>Facebook:</strong> <code>/^_fb/</code>, <code>/^fb_/</code>, <code>_fbp</code></li>
-								<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code></li>
-								<li><strong>Matomo:</strong> <code>/^_pk_/</code>, <code>/^mtm_/</code></li>
+								<li><strong>Google Analytics:</strong> <code>/^_ga/</code> <?php esc_html_e( '(regex)', 'warder-cookie-consent' ); ?>, <code>_gid</code>, <code>_gat</code></li>
+								<li><strong>Facebook:</strong> <code>/^_fb/</code> <?php esc_html_e( '(regex)', 'warder-cookie-consent' ); ?>, <code>/^fb_/</code> <?php esc_html_e( '(regex)', 'warder-cookie-consent' ); ?>, <code>_fbp</code></li>
+								<li><strong>Google Ads:</strong> <code>_gcl_au</code>, <code>/^_gcl_/</code> <?php esc_html_e( '(regex)', 'warder-cookie-consent' ); ?></li>
+								<li><strong>Matomo:</strong> <code>/^_pk_/</code> <?php esc_html_e( '(regex)', 'warder-cookie-consent' ); ?>, <code>/^mtm_/</code> <?php esc_html_e( '(regex)', 'warder-cookie-consent' ); ?></li>
 							</ul>
 						</div>
 					</div>


### PR DESCRIPTION
This release resolves a critical bug in the Add Cookie admin UI where the form was nested inside the main settings form, causing submissions to be lost or misrouted due to HTML's prohibition on nested `<form>` elements. The fix relocates the Add Cookie form to render per-category and submits via an out-of-DOM form construction, ensuring each category's cookies are added reliably without interfering with the parent settings form. Version 1.5.1 ships alongside documentation improvements that clarify the distinction between exact-match and regex-based cookie name patterns, helping administrators avoid configuration mistakes when targeting cookies. The changes are confined to the PHP admin layer and documentation files, with no impact on the JavaScript bundle or runtime consent behavior. Version metadata is synchronized across `warder-cookie-consent.php`, `readme.txt`, `CHANGELOG.md`, and `package.json` per project conventions.

**Bug Fixes:**
- Moved the Add Cookie form inside each category section (`simple-cookie-consent.php`) so each category has its own submission scope, preventing cross-category submission errors (commit 2c27f89).
- Replaced the nested-form submission path with an out-of-DOM form construction that posts independently of the surrounding settings form, eliminating the HTML5 invalid-nesting bug that silently dropped Add Cookie requests (commit ba4b45a).

**Documentation and Developer Guidance:**
- Clarified the regex-vs-exact-match semantics in the Add Cookie form help text, making it explicit that names wrapped in `/.../` are treated as regex patterns while plain strings require exact matches (commit 81402c7).
- Added Matomo to the Common Cookie Patterns examples in the admin UI and readme, giving administrators a concrete recipe for a widely deployed analytics platform (commit dfc250b).

**Release Metadata:**
- Bumped the plugin version to 1.5.1 across `warder-cookie-consent.php`, `readme.txt` (Stable tag plus Changelog and Upgrade Notice entries), `CHANGELOG.md`, and `package.json`, keeping all version sources in sync as required by the project's versioning policy (commit 33d9da3).

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/cookie-field-below-add-cookie-to-cat-btn/CHANGELOG.md) (Modified)
- [`package.json`](https://github.com/imagewize/warder-cookie-consent/blob/cookie-field-below-add-cookie-to-cat-btn/package.json) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/cookie-field-below-add-cookie-to-cat-btn/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/cookie-field-below-add-cookie-to-cat-btn/warder-cookie-consent.php) (Modified)

*Dependency lock files updated:* package-lock.json,