### PR TITLE
Fix/slimstat Defaults And Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [2.1.1] - 2026-05-30
+
+### Changed
+- Removed `wp_slimstat` (Slimstat Analytics) from the default `warder_blocked_scripts` list — Slimstat is not bundled with WordPress or WooCommerce, so blocking it by default added dead code for the vast majority of sites. Use the `warder_blocked_scripts` filter to add it when needed.
+
+### Documentation
+- Updated README to reflect current necessary-category cookie defaults (WordPress core + WooCommerce session cookies) and analytics defaults (including `sbjs_*`).
+- Added "Common examples" to the Automatic Script Blocking section showing how to extend `warder_blocked_scripts` with Slimstat and MonsterInsights.
+
 ## [2.1.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This means you can easily configure which cookies to block and when to allow the
 ### Cookie Categories
 
 The default configuration includes:
-- **Necessary cookies**: Always enabled, required for basic website functionality. Pre-populated with WordPress core cookies (`wordpress_*`, `wp-settings-*`, `wordpress_logged_in_*`, `wordpress_sec_*`) and WooCommerce session & cart cookies (`wp_woocommerce_session_*`, `woocommerce_cart_hash`, `woocommerce_items_in_cart`, `woocommerce_recently_viewed`).
+- **Necessary cookies**: Always enabled, required for basic website functionality. Pre-populated with WordPress core cookies (`wordpress_logged_in_*`, `wordpress_sec_*`, `wordpress_test_cookie`, `wp-settings-*`) and WooCommerce session & cart cookies (`wp_woocommerce_session_*`, `woocommerce_cart_hash`, `woocommerce_items_in_cart`, `woocommerce_recently_viewed`).
 - **Analytics cookies**: Optional tracking and analytics cookies, pre-populated with patterns for Google Analytics (`/^_ga/`, `_gid`, `_gat`), Matomo (`/^_pk_/`, `/^mtm_/`), and SourceBuster (`/^sbjs_/`).
 
 > Plausible Analytics is cookieless by design, so it needs no patterns here — there are no cookies to clear.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ This means you can easily configure which cookies to block and when to allow the
 ### Cookie Categories
 
 The default configuration includes:
-- **Necessary cookies**: Always enabled, required for basic website functionality
-- **Analytics cookies**: Optional tracking and analytics cookies, pre-populated with patterns for Google Analytics (`/^_ga/`, `_gid`, `_gat`) and Matomo (`/^_pk_/`, `/^mtm_/`)
+- **Necessary cookies**: Always enabled, required for basic website functionality. Pre-populated with WordPress core cookies (`wordpress_*`, `wp-settings-*`, `wordpress_logged_in_*`, `wordpress_sec_*`) and WooCommerce session & cart cookies (`wp_woocommerce_session_*`, `woocommerce_cart_hash`, `woocommerce_items_in_cart`, `woocommerce_recently_viewed`).
+- **Analytics cookies**: Optional tracking and analytics cookies, pre-populated with patterns for Google Analytics (`/^_ga/`, `_gid`, `_gat`), Matomo (`/^_pk_/`, `/^mtm_/`), and SourceBuster (`/^sbjs_/`).
 
 > Plausible Analytics is cookieless by design, so it needs no patterns here — there are no cookies to clear.
 
@@ -118,6 +118,34 @@ Gate the Matomo tracking snippet the same way:
 ```
 
 The matching `/^_pk_/` and `/^mtm_/` patterns in the analytics category clear Matomo's cookies if consent is later withdrawn.
+
+### Automatic Script Blocking
+
+The plugin automatically blocks a set of known WordPress script handles before analytics consent is given — no `data-category` attributes needed on those scripts. The built-in list covers:
+
+| Script handle | Script |
+|---|---|
+| `sourcebuster-js` | WooCommerce SourceBuster (sets `sbjs_*` cookies) |
+| `wc-order-attribution` | WooCommerce order attribution |
+
+To add more scripts, use the `warder_blocked_scripts` filter:
+
+```php
+add_filter( 'warder_blocked_scripts', function( $scripts ) {
+    $scripts['my-tracking-script'] = 'analytics';
+    return $scripts;
+} );
+```
+
+#### Common examples
+
+```php
+// Slimstat Analytics
+$scripts['wp_slimstat'] = 'analytics';
+
+// MonsterInsights
+$scripts['monsterinsights-frontend'] = 'analytics';
+```
 
 ### Managing Third-party Cookies
 

--- a/inc/frontend.php
+++ b/inc/frontend.php
@@ -143,9 +143,8 @@ function warder_block_script_until_consent( $tag, $handle ) {
 	$blocked = apply_filters(
 		'warder_blocked_scripts',
 		array(
-			'sourcebuster-js'    => 'analytics',
+			'sourcebuster-js'      => 'analytics',
 			'wc-order-attribution' => 'analytics',
-			'wp_slimstat'        => 'analytics',
 		)
 	);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,12 @@ https://github.com/imagewize/warder-cookie-consent
 `src/index.js` imports the [vanilla-cookieconsent v3](https://github.com/orestbida/cookieconsent) library. To build from source: run `npm install`, then `npx webpack` (or `npx webpack --watch` during development).
 
 == Changelog ==
+
+= 2.1.1 =
+*2026-05-30*
+
+* Changed: removed `wp_slimstat` from the default `warder_blocked_scripts` list — Slimstat is not bundled with WordPress or WooCommerce, so blocking it by default was dead code for most sites. Add it back via the `warder_blocked_scripts` filter if needed.
+* Docs: updated README to document the necessary-category cookie defaults (WordPress core + WooCommerce) and analytics defaults (including `sbjs_*`); added common `warder_blocked_scripts` examples for Slimstat and MonsterInsights.
 
 = 2.1.0 =
 *2026-05-30*
@@ -200,6 +206,9 @@ https://github.com/imagewize/warder-cookie-consent
 * Initial release
 
 == Upgrade Notice ==
+
+= 2.1.1 =
+Removes Slimstat from the default automatic script-blocking list (use the `warder_blocked_scripts` filter to add it back if needed). README updated to document WooCommerce cookie defaults and script-blocking examples.
 
 = 2.1.0 =
 Adds automatic script blocking for SourceBuster.js, WooCommerce order attribution, and Slimstat before consent is given. Necessary cookie defaults now include the full WordPress and WooCommerce session cookie set. The `sbjs_*` pattern moves to analytics — if you manually placed it under necessary, you can remove the duplicate.

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 2.1.0
+ * Version: 2.1.1
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WARDER_VERSION', '2.1.0' );
+define( 'WARDER_VERSION', '2.1.1' );
 define( 'WARDER_PLUGIN_FILE', __FILE__ );
 
 require_once plugin_dir_path( __FILE__ ) . 'inc/defaults.php';


### PR DESCRIPTION
This branch ships a patch release (version 2.1.1) that corrects the plugin's default script-blocking behavior and substantially improves the project documentation. The core change removes Slimstat from the default `warder_blocked_scripts` list in `inc/frontend.php`, ensuring the plugin no longer blocks that analytics script out-of-the-box and aligns runtime behavior with documented expectations. Alongside the fix, the README is expanded to cover the script blocker, WooCommerce cookies, and developer filter examples, and the "necessary" cookie patterns are corrected to match the actual shipped defaults. The version bump is propagated across all canonical version locations (`warder-cookie-consent.php`, `readme.txt`, `package.json`, and `CHANGELOG.md`) per the project's versioning policy. The result is a small, low-risk release with 6 files changed (53 insertions, 8 deletions) that improves both default correctness and documentation accuracy.

**Default Behavior Fix:**
- Removed Slimstat from the default `warder_blocked_scripts` list in `inc/frontend.php` so the plugin no longer blocks the Slimstat analytics script by default, preventing unexpected suppression of analytics on fresh installs.
- The change narrows the out-of-the-box blocking scope, leaving script blocking to be configured explicitly rather than imposing an opinionated default.

**Documentation Updates:**
- Expanded `README.md` to document the script blocker, WooCommerce cookie handling, and developer filter examples, giving integrators clearer guidance on extending and customizing behavior.
- Corrected the "necessary" cookie patterns in the README so they match the canonical defaults defined in the plugin, eliminating a documentation/code mismatch.

**Version Release (2.1.1):**
- Bumped the version to 2.1.1 across all canonical locations: the `Version:` header and `WARDER_VERSION` constant in `warder-cookie-consent.php`, the `Stable tag:` in `readme.txt`, the `version` field in `package.json`, and a new heading in `CHANGELOG.md`.
- Updated `readme.txt` and `CHANGELOG.md` with corresponding changelog entries to keep the WordPress.org-readable metadata consistent with the release.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/fix/slimstat-defaults-and-readme/CHANGELOG.md) (Modified)
- [`README.md`](https://github.com/imagewize/warder-cookie-consent/blob/fix/slimstat-defaults-and-readme/README.md) (Modified)
- [`inc/frontend.php`](https://github.com/imagewize/warder-cookie-consent/blob/fix/slimstat-defaults-and-readme/inc/frontend.php) (Modified)
- [`package.json`](https://github.com/imagewize/warder-cookie-consent/blob/fix/slimstat-defaults-and-readme/package.json) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/fix/slimstat-defaults-and-readme/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/fix/slimstat-defaults-and-readme/warder-cookie-consent.php) (Modified)