### PR TITLE
Docs Contributing Guide

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -21,6 +21,7 @@ vendor/*
 .vibe/*
 AGENTS.md
 CLAUDE.md
+CONTRIBUTING.md
 README.md
 dev.md
 docs/*

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,7 @@ docs export-ignore
 
 AGENTS.md export-ignore
 CLAUDE.md export-ignore
+CONTRIBUTING.md export-ignore
 README.md export-ignore
 dev.md export-ignore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [2.1.2] - 2026-05-30
+
+### Documentation
+- Added `CONTRIBUTING.md` at the repository root covering build-from-source, development setup, dependencies, and how to submit changes.
+- Trimmed the developer-facing "Build from Source", "Development", and "Dependencies" sections out of the README and replaced them with a "Contributing" pointer to `CONTRIBUTING.md` and `docs/dev.md`. Renumbered the Composer install method accordingly.
+
 ## [2.1.1] - 2026-05-30
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Warder Cookie Consent
+
+Thanks for your interest in improving Warder Cookie Consent! This guide covers how to
+build the plugin from source, set up a development environment, and submit changes.
+
+For a deeper technical reference on how the plugin loads settings, blocks scripts, and
+manages cookies, see [`docs/dev.md`](docs/dev.md).
+
+## Build from Source
+
+1. Clone this repository
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Build the plugin:
+   ```bash
+   npx webpack
+   ```
+4. Upload the plugin folder to your WordPress plugins directory
+
+## Development
+
+PHP 8.0+ is required. To set up the development environment:
+
+```bash
+# Install dependencies
+npm install
+
+# Build for production
+npx webpack
+
+# Watch for changes
+npx webpack --watch
+```
+
+The frontend bundle is built from `src/index.js` into `dist/cookieconsent.bundle.js`.
+There are no automated tests.
+
+## Dependencies
+
+- [CookieConsent v3](https://github.com/orestbida/cookieconsent) - Core cookie consent functionality
+- [webpack](https://webpack.js.org/) - For bundling assets
+- [style-loader](https://webpack.js.org/loaders/style-loader/) - For loading CSS
+- [css-loader](https://webpack.js.org/loaders/css-loader/) - For processing CSS
+
+## Submitting Changes
+
+1. Fork the repository and create a feature branch off `main`.
+2. Make your changes and rebuild the bundle (`npx webpack`) if you touched anything under `src/`.
+3. Open a pull request against `main` with a clear description of what changed and why.

--- a/README.md
+++ b/README.md
@@ -29,20 +29,7 @@ A lightweight plugin that implements GDPR-compliant cookie consent functionality
 3. Upload the extracted folder to your `/wp-content/plugins/` directory
 4. Activate the plugin through the WordPress admin panel
 
-### Method 3: Build from Source
-
-1. Clone this repository
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Build the plugin:
-   ```bash
-   npx webpack
-   ```
-4. Upload the plugin folder to your WordPress plugins directory
-
-### Method 4: Using Composer
+### Method 3: Using Composer
 
 You can also install the plugin using Composer:
 ```bash
@@ -155,27 +142,11 @@ The plugin automatically handles third-party cookies by:
 
 For detailed implementation guides, see [`docs/dev.md`](docs/dev.md).
 
-## Dependencies
+## Contributing
 
-- [CookieConsent v3](https://github.com/orestbida/cookieconsent) - Core cookie consent functionality
-- [webpack](https://webpack.js.org/) - For bundling assets
-- [style-loader](https://webpack.js.org/loaders/style-loader/) - For loading CSS
-- [css-loader](https://webpack.js.org/loaders/css-loader/) - For processing CSS
-
-## Development
-
-To set up the development environment:
-
-```bash
-# Install dependencies
-npm install
-
-# Build for production
-npx webpack
-
-# Watch for changes
-npx webpack --watch
-```
+Want to build from source, set up a development environment, or submit changes? See
+[`CONTRIBUTING.md`](CONTRIBUTING.md). For a deeper technical reference, see
+[`docs/dev.md`](docs/dev.md).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 2.1.1
+Stable tag: 2.1.2
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -65,6 +65,12 @@ https://github.com/imagewize/warder-cookie-consent
 `src/index.js` imports the [vanilla-cookieconsent v3](https://github.com/orestbida/cookieconsent) library. To build from source: run `npm install`, then `npx webpack` (or `npx webpack --watch` during development).
 
 == Changelog ==
+
+= 2.1.2 =
+*2026-05-30*
+
+* Docs: added `CONTRIBUTING.md` at the repository root with build-from-source, development setup, dependencies, and contribution guidelines.
+* Docs: moved the developer-facing build/development/dependencies sections out of the README into `CONTRIBUTING.md`, leaving a short "Contributing" pointer; renumbered the Composer install method.
 
 = 2.1.1 =
 *2026-05-30*
@@ -206,6 +212,9 @@ https://github.com/imagewize/warder-cookie-consent
 * Initial release
 
 == Upgrade Notice ==
+
+= 2.1.2 =
+Documentation-only release: adds a `CONTRIBUTING.md` and slims the README to user-facing docs. No functional changes.
 
 = 2.1.1 =
 Removes Slimstat from the default automatic script-blocking list (use the `warder_blocked_scripts` filter to add it back if needed). README updated to document WooCommerce cookie defaults and script-blocking examples.

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 2.1.1
+ * Version: 2.1.2
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WARDER_VERSION', '2.1.1' );
+define( 'WARDER_VERSION', '2.1.2' );
 define( 'WARDER_PLUGIN_FILE', __FILE__ );
 
 require_once plugin_dir_path( __FILE__ ) . 'inc/defaults.php';


### PR DESCRIPTION
This is a documentation-focused release that extracts developer-facing material out of the README into a dedicated `CONTRIBUTING.md` and bumps the plugin to version 2.1.2. The new `CONTRIBUTING.md` (51 lines) consolidates the build-from-source instructions, development environment setup, dependency list, and change-submission guidelines that were previously scattered through the README, leaving the README focused on user-facing installation and usage. The README's "Build from Source", "Development", and "Dependencies" sections were removed and replaced with a concise "Contributing" pointer, which also required renumbering the Composer install method from Method 4 to Method 3. Distribution metadata (`.distignore` and `.gitattributes`) was updated to exclude the new file from the packaged plugin, and the version bump was propagated across all canonical version locations. There are no functional or behavioral changes to the plugin itself.

**Documentation and Developer Guidance:**
- Added `CONTRIBUTING.md` (51 lines) at the repository root covering build-from-source, development setup, dependencies, and how to submit changes, centralizing previously fragmented developer documentation.
- Trimmed the "Build from Source", "Development", and "Dependencies" sections from `README.md` and replaced them with a short "Contributing" section pointing to `CONTRIBUTING.md` and `docs/dev.md`, keeping the README focused on end users.
- Renumbered the Composer installation method from Method 4 to Method 3 to reflect the removal of the standalone build-from-source method.

**Version Bump (2.1.1 to 2.1.2):**
- Updated the canonical version in `warder-cookie-consent.php` (`Version:` header and `WARDER_VERSION` constant), `package.json`, and `readme.txt` (`Stable tag:`).
- Added 2.1.2 entries to `CHANGELOG.md`, plus `== Changelog ==` and `== Upgrade Notice ==` sections in `readme.txt`, documenting this as a documentation-only release with no functional changes.

**Distribution Packaging:**
- Added `CONTRIBUTING.md` to `.distignore` and `.gitattributes` (`export-ignore`) so the developer guide is excluded from the distributed plugin ZIP and the WordPress.org package, consistent with the existing handling of `README.md` and `CLAUDE.md`.

**Files Changed:**

- [`.distignore`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/.distignore) (Modified)
- [`.gitattributes`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/.gitattributes) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/CHANGELOG.md) (Modified)
- [`README.md`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/README.md) (Modified)
- [`package.json`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/package.json) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/warder-cookie-consent.php) (Modified)
- [`CONTRIBUTING.md`](https://github.com/imagewize/warder-cookie-consent/blob/docs-contributing-guide/CONTRIBUTING.md) (Added)