### PR TITLE
Chore/add Uninstall Handler

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -40,6 +40,7 @@ temperature = 1.0
 input_price = 1.5
 output_price = 7.5
 thinking = "high"
+supports_images = true
 
 [[models]]
 name = "devstral-small-latest"
@@ -71,14 +72,6 @@ timeout_seconds = 2.0
 save_dir = "/Users/jasperfrumau/.vibe/logs/session"
 session_prefix = "session"
 enabled = true
-
-[tools.search_replace]
-permission = "ask"
-allowlist = []
-denylist = []
-max_content_size = 100000
-create_backup = false
-fuzzy_threshold = 0.9
 
 [tools.bash]
 permission = "ask"
@@ -165,13 +158,6 @@ exclude_patterns = [
 ]
 codeignore_file = ".vibeignore"
 
-[tools.read_file]
-permission = "always"
-allowlist = []
-denylist = []
-max_read_bytes = 64000
-max_state_history = 10
-
 [tools.todo]
 permission = "always"
 allowlist = []
@@ -184,3 +170,16 @@ allowlist = []
 denylist = []
 max_write_bytes = 64000
 create_parent_dirs = true
+
+[tools.read]
+permission = "always"
+allowlist = []
+denylist = []
+max_read_bytes = 64000
+max_state_history = 10
+
+[tools.edit]
+permission = "ask"
+allowlist = []
+denylist = []
+fuzzy_threshold = 0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [2.2.0] - 2026-06-05
+
+### Added
+- `uninstall.php` — WordPress-standard uninstall handler that removes `warder_options` and `warder_options_last_updated` from the database when the plugin is deleted via the WordPress admin.
+- **Danger Zone** section at the bottom of the settings page with a "Remove Data on Uninstall" checkbox (unchecked by default). Settings are preserved on uninstall unless the user explicitly opts in, matching the convention used by major plugins (Yoast SEO, WooCommerce).
+
 ## [2.1.4] - 2026-06-04
 
 ### Documentation

--- a/docs/wordpress-options-api-usage.md
+++ b/docs/wordpress-options-api-usage.md
@@ -1,0 +1,184 @@
+# WordPress Options API Usage & Improvements
+
+This document reviews the current implementation of the WordPress Options API in the Warder Cookie Consent plugin and identifies opportunities for improvement.
+
+## Current Implementation
+
+### Options Storage
+
+The plugin stores all settings under a single option key: `warder_options`.
+
+An additional timestamp option `warder_options_last_updated` is used for cache busting when settings change.
+
+### API Functions Used
+
+| Function | Location | Purpose |
+|----------|----------|---------|
+| `get_option()` | `inc/defaults.php`, `inc/settings.php` | Retrieves `warder_options` from database |
+| `add_option()` | `inc/settings.php` | Adds default options on first activation |
+| `update_option()` | `inc/settings.php`, `inc/ajax.php` | Saves updated settings |
+| `register_setting()` | `inc/settings.php` | Registers settings with sanitization callback |
+| `delete_option()` | `uninstall.php` | Removes options on uninstall when user has opted in |
+
+### Settings Registration Flow
+
+1. **`warder_register_settings()`** (hooked to `admin_init`):
+   - Registers the `warder_options` setting with `register_setting()`
+   - Sanitization callback: `warder_validate_options()`
+   - Adds default options via `add_option()` if option doesn't exist
+
+2. **`warder_plugin_activate()`** (hooked to `register_activation_hook`):
+   - Merges existing options with defaults using `wp_parse_args()`
+   - Updates the merged options via `update_option()`
+
+3. **`warder_get_merged_options()`** (in `inc/defaults.php`):
+   - Retrieves current options via `get_option()`
+   - Deep-merges with defaults using `wp_parse_args()`
+   - Ensures a complete options structure is always returned
+
+## What's Working Well
+
+### ✅ Proper Use of Options API
+
+- **Single option key**: All settings are stored under `warder_options`, avoiding database bloat from multiple option rows
+- **Default merging**: `warder_get_merged_options()` ensures defaults are always available, preventing undefined index notices
+- **Sanitization**: Both `warder_sanitize_options_input()` (recursive text sanitization) and `warder_validate_options()` (structural validation and whitelisting) provide robust input cleaning
+- **Type safety**: The validation callback explicitly handles boolean flags, whitelisted values, and sanitized text
+
+### ✅ Activation Handling
+
+- The activation hook merges existing options with new defaults, which is useful for:
+  - Preserving user customizations when defaults change in new versions
+  - Adding new default cookie categories or settings
+
+### ✅ Settings Registration
+
+- Using `register_setting()` with a sanitization callback follows WordPress best practices
+- The `'type' => 'array'` parameter correctly declares the option structure
+
+## Identified Improvements
+
+### 1. Uninstall Cleanup ✅
+
+**Implemented in 2.2.0** via `uninstall.php` (Option B — the WordPress Plugin Handbook recommended approach). WordPress executes this file directly when the plugin is deleted, without loading the plugin first, making it more reliable than `register_uninstall_hook()`.
+
+Cleanup is **opt-in**: the user must enable "Remove Data on Uninstall" in the Danger Zone section of the settings page before the options are deleted. This matches the convention used by Yoast SEO, WooCommerce, and other major plugins — data is preserved by default.
+
+```php
+<?php
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+$options = get_option( 'warder_options', array() );
+
+if ( ! empty( $options['remove_data_on_uninstall'] ) ) {
+    delete_option( 'warder_options' );
+    delete_option( 'warder_options_last_updated' );
+}
+```
+
+### 2. Activation Hook Redundancy
+
+**Issue**: There's a subtle redundancy between `warder_register_settings()` and `warder_plugin_activate()`:
+
+- `warder_register_settings()` (on `admin_init`): Adds default options if they don't exist
+- `warder_plugin_activate()` (on activation): Merges and updates options with defaults
+
+On **first activation**:
+1. Plugin is activated → `warder_plugin_activate()` runs → merges empty array with defaults → saves defaults
+2. User visits admin → `warder_register_settings()` runs → sees options exist → skips `add_option()`
+
+On **subsequent visits**: Both functions check and potentially update, but the activation hook only runs once.
+
+**Impact**: Minimal - the redundancy ensures defaults are set, but it's not optimal.
+
+**Recommended Solution**: 
+
+The current implementation is actually **intentional and useful** because:
+- `warder_plugin_activate()` merges existing options with NEW defaults when plugin is activated (e.g., after an update with new default categories)
+- This ensures users get new default settings without losing their customizations
+
+The `add_option()` in `warder_register_settings()` serves as a fallback for the first admin visit if activation somehow didn't run.
+
+**Verdict**: Keep both. The redundancy is minimal overhead and provides safety.
+
+### 3. Option Autoloading
+
+**Current State**: No explicit autoload setting is specified when adding options.
+
+**Impact**: WordPress defaults to autoloading all options, which is fine for this plugin since:
+- Only two options are stored (`warder_options`, `warder_options_last_updated`)
+- The options are needed on both admin and frontend
+- The `warder_options` array is not excessively large
+
+**Recommendation**: No change needed. For larger plugins with many options, consider setting `'autoload' => false` for options not needed on every page load, but this plugin's footprint is small enough that autoloading is acceptable.
+
+## Implementation Checklist
+
+- [x] Add uninstall cleanup via `uninstall.php` (implemented in 2.2.0)
+- [x] Opt-in "Remove Data on Uninstall" setting so data is preserved by default
+- [ ] Test uninstall to verify options are removed when opt-in is enabled
+- [ ] Test that options are preserved when opt-in is disabled
+
+## Best Practices Reference
+
+### WordPress Options API Best Practices
+
+1. **Use a single option for related settings** - ✅ Implemented (`warder_options`)
+2. **Always sanitize and validate** - ✅ Implemented (`warder_validate_options`)
+3. **Provide defaults** - ✅ Implemented (`warder_get_default_options`, `warder_get_merged_options`)
+4. **Clean up on uninstall** - ✅ Implemented (`uninstall.php`, opt-in via settings)
+5. **Use `register_setting()` for admin settings** - ✅ Implemented
+6. **Prefix everything** - ✅ Implemented (`warder_` prefix)
+
+### Data Merge Strategy
+
+The plugin uses `wp_parse_args()` for merging, which is appropriate for:
+- Flat arrays (top-level settings)
+- Shallow merging needs
+
+For deeply nested structures like `cookie_categories`, the current approach works because:
+- `wp_parse_args()` handles the top-level merge
+- The validation function explicitly processes nested arrays
+- Defaults are comprehensive and rarely change structure
+
+## Code Examples
+
+### Current Pattern (Good)
+
+```php
+// Retrieving with defaults
+function warder_get_merged_options() {
+    $options         = get_option( 'warder_options', array() );
+    $default_options = warder_get_default_options();
+    return wp_parse_args( $options, $default_options );
+}
+```
+
+### Implemented Pattern (uninstall.php)
+
+```php
+// uninstall.php — executed by WordPress on plugin deletion
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+$options = get_option( 'warder_options', array() );
+
+if ( ! empty( $options['remove_data_on_uninstall'] ) ) {
+    delete_option( 'warder_options' );
+    delete_option( 'warder_options_last_updated' );
+}
+```
+
+## Testing Considerations
+
+When implementing the uninstall hook:
+
+1. **Test fresh install**: Verify options are created correctly
+2. **Test update**: Verify existing options are preserved
+3. **Test uninstall**: Verify options are removed from database
+4. **Test reinstall**: Verify plugin works correctly after uninstall/reinstall
+
+## Related Files
+
+- `inc/defaults.php` - Default options and merging logic
+- `inc/settings.php` - Settings registration, validation, activation
+- `warder-cookie-consent.php` - Main plugin file (where uninstall hook should be added)

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -343,6 +343,25 @@ function warder_render_options_page() {
 			}
 			?>
 
+			<!-- Danger Zone Section -->
+			<h2 style="color: #d63638; border-top: 1px solid #dcdcde; padding-top: 20px; margin-top: 30px;">
+				<?php esc_html_e( 'Danger Zone', 'warder-cookie-consent' ); ?>
+			</h2>
+			<table class="form-table">
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Remove Data on Uninstall', 'warder-cookie-consent' ); ?></th>
+					<td>
+						<label>
+							<input type="checkbox" name="warder_options[remove_data_on_uninstall]" <?php checked( ! empty( $options['remove_data_on_uninstall'] ), true ); ?> />
+							<?php esc_html_e( 'Delete all plugin settings from the database when this plugin is uninstalled', 'warder-cookie-consent' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'When checked, all Warder Cookie Consent settings will be permanently removed from your database when you delete the plugin via Plugins > Delete. Leave unchecked to preserve your settings (useful if you plan to reinstall later).', 'warder-cookie-consent' ); ?>
+						</p>
+					</td>
+				</tr>
+			</table>
+
 			<!-- Submit button for main settings -->
 			<?php submit_button( __( 'Save All Settings', 'warder-cookie-consent' ), 'primary', 'submit', false ); ?>
 		</form>

--- a/inc/defaults.php
+++ b/inc/defaults.php
@@ -27,6 +27,7 @@ function warder_get_default_options() {
 		'privacy_policy_url'          => '#privacy-policy',
 		'show_preferences_toggle'     => true,
 		'preferences_toggle_position' => 'bottom-right',
+		'remove_data_on_uninstall'    => false,
 		'cookie_categories'           => array(
 			'necessary' => array(
 				'title'       => 'Strictly Necessary',

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -85,6 +85,7 @@ function warder_validate_options( $input ) {
 	$valid['show_preferences_toggle']     = isset( $input['show_preferences_toggle'] ) ? true : false;
 	$valid['preferences_toggle_position'] = isset( $input['preferences_toggle_position'] ) && array_key_exists( $input['preferences_toggle_position'], warder_allowed_toggle_positions() )
 		? $input['preferences_toggle_position'] : 'bottom-right';
+	$valid['remove_data_on_uninstall']    = isset( $input['remove_data_on_uninstall'] ) ? true : false;
 
 	if ( isset( $input['cookie_categories'] ) && is_array( $input['cookie_categories'] ) ) {
 		$valid['cookie_categories'] = array();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 2.1.4
+Stable tag: 2.2.0
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -67,6 +67,12 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 5. Regex cookie matching and adding custom categories
 
 == Changelog ==
+
+= 2.2.0 =
+*2026-06-05*
+
+* Added: `uninstall.php` — WordPress-standard uninstall handler. Removes `warder_options` and `warder_options_last_updated` from the database when the plugin is deleted, but only when the user has opted in.
+* Added: **Danger Zone** section in settings with a "Remove Data on Uninstall" checkbox (unchecked by default). Data is preserved on uninstall unless explicitly opted in — consistent with Yoast SEO, WooCommerce, and other major plugins.
 
 = 2.1.4 =
 *2026-06-04*
@@ -225,6 +231,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 2.2.0 =
+Adds optional database cleanup on uninstall. Settings are preserved by default — tick "Remove Data on Uninstall" in the Danger Zone section of the settings page before deleting the plugin if you want a clean removal.
 
 = 2.1.4 =
 Documentation only: adds listing screenshots and captions. No functional changes.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin uninstall handler.
+ *
+ * Runs when the plugin is deleted via Plugins > Delete in the WordPress admin.
+ * Only removes database options when the user has explicitly opted in via the
+ * "Remove Data on Uninstall" setting.
+ *
+ * @package Warder_Cookie_Consent
+ */
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+$options = get_option( 'warder_options', array() );
+
+if ( ! empty( $options['remove_data_on_uninstall'] ) ) {
+	delete_option( 'warder_options' );
+	delete_option( 'warder_options_last_updated' );
+}

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 2.1.4
+ * Version: 2.2.0
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WARDER_VERSION', '2.1.4' );
+define( 'WARDER_VERSION', '2.2.0' );
 define( 'WARDER_PLUGIN_FILE', __FILE__ );
 
 require_once plugin_dir_path( __FILE__ ) . 'inc/defaults.php';


### PR DESCRIPTION
This release (2.2.0) introduces opt-in uninstall cleanup functionality, allowing site administrators to automatically remove all plugin data from the WordPress database when the plugin is deleted. A new `remove_data_on_uninstall` boolean setting was added to the options schema, and a dedicated `uninstall.php` handler was introduced to execute the cleanup when WordPress triggers the uninstall hook. The implementation follows WordPress best practices by using the `uninstall.php` pattern rather than a `register_uninstall_hook` callback, ensuring cleanup runs reliably on deletion. Version bumps were applied consistently across `warder-cookie-consent.php`, `package.json`, `readme.txt`, and `CHANGELOG.md` per the project's versioning convention.

**Uninstall Cleanup Implementation:**
- Added `uninstall.php` at the plugin root, which deletes the `warder_options` and `warder_options_last_updated` database entries when the plugin is removed via the WordPress admin.
- Introduced `remove_data_on_uninstall` as an opt-in boolean setting (defaults to `false`), ensuring existing installations retain data unless the administrator explicitly enables cleanup before deletion.
- Updated `inc/defaults.php` and `inc/settings.php` to register, sanitize, and persist the new setting alongside the existing options schema.

**Documentation and Developer Guidance:**
- Added `docs/wordpress-options-api-usage.md` documenting the Options API integration, including the new `remove_data_on_uninstall` field, to support developers consuming plugin settings programmatically.
- Updated `readme.txt` with the 2.2.0 stable tag, changelog entry, and upgrade notice describing the new opt-in behavior.

**Project Configuration:**
- Updated `.vibe/config.toml` to add `supports_images` and consolidate tool definitions, aligning the project's AI-assisted development configuration with current tooling.

**Files Changed:**

- [`.vibe/config.toml`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/.vibe/config.toml) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/CHANGELOG.md) (Modified)
- [`inc/admin.php`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/inc/admin.php) (Modified)
- [`inc/defaults.php`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/inc/defaults.php) (Modified)
- [`inc/settings.php`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/inc/settings.php) (Modified)
- [`package.json`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/package.json) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/warder-cookie-consent.php) (Modified)
- [`docs/wordpress-options-api-usage.md`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/docs/wordpress-options-api-usage.md) (Added)
- [`uninstall.php`](https://github.com/imagewize/warder-cookie-consent/blob/chore/add-uninstall-handler/uninstall.php) (Added)