### PR TITLE
Fix Astra Pro CSS incompatibility affecting preferences toggle icon visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [2.1.5] - 2026-06-26
+
+### Fixed
+- Added `padding: 0` to `.warder-preferences-toggle` to prevent Astra Pro theme styles (padding: 15px 30px on button elements) from distorting the toggle button and hiding its icon.
+
 ## [2.1.4] - 2026-06-04
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Warder Cookie Consent are documented here.
 ## [2.1.5] - 2026-06-26
 
 ### Fixed
-- Added `padding: 0` to `.warder-preferences-toggle` to prevent Astra Pro theme styles (padding: 15px 30px on button elements) from distorting the toggle button and hiding its icon.
+- Added `padding: 0` to `.warder-preferences-toggle` to prevent Astra Pro theme styles (padding: 15px 30px on button elements) from distorting the toggle button and hiding its icon. Props: gbogdan.
 
 ## [2.1.4] - 2026-06-04
 

--- a/inc/frontend.php
+++ b/inc/frontend.php
@@ -68,6 +68,7 @@ function warder_get_preferences_toggle_css() {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: 0;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
 	z-index: 9999;
 	transition: background 0.2s ease, transform 0.2s ease;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 2.1.4
+Stable tag: 2.1.5
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -67,6 +67,11 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 5. Regex cookie matching and adding custom categories
 
 == Changelog ==
+
+= 2.1.5 =
+*2026-06-26*
+
+* Fixed: added `padding: 0` to `.warder-preferences-toggle` to prevent Astra Pro theme button styles (padding: 15px 30px) from distorting the floating toggle button and hiding its icon.
 
 = 2.1.4 =
 *2026-06-04*
@@ -225,6 +230,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 2.1.5 =
+Fixes a visual regression when Astra Pro is active: the floating preferences toggle button was inheriting button padding from the theme, distorting its shape and hiding the icon.
 
 = 2.1.4 =
 Documentation only: adds listing screenshots and captions. No functional changes.

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Warder Cookie Consent ===
-Contributors: rhand
+Contributors: rhand, gbogdan
 Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
@@ -72,6 +72,7 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 *2026-06-26*
 
 * Fixed: added `padding: 0` to `.warder-preferences-toggle` to prevent Astra Pro theme button styles (padding: 15px 30px) from distorting the floating toggle button and hiding its icon.
+* Props: gbogdan for reporting and fixing the Astra Pro CSS incompatibility.
 
 = 2.1.4 =
 *2026-06-04*

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 2.1.4
+ * Version: 2.1.5
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WARDER_VERSION', '2.1.4' );
+define( 'WARDER_VERSION', '2.1.5' );
 define( 'WARDER_PLUGIN_FILE', __FILE__ );
 
 require_once plugin_dir_path( __FILE__ ) . 'inc/defaults.php';


### PR DESCRIPTION
Fixes a CSS incompatibility with Astra Pro theme styles.

The ".warder-preferences-toggle" element was inheriting padding values from Astra Pro (15px 30px), causing the toggle button to become distorted and the icon to disappear.

Added:
.warder-preferences-toggle {
    padding: 0;
}

This restores the intended appearance and ensures the toggle icon remains visible when Warder Cookie Consent is used alongside Astra Pro.

Root cause: CSS specificity conflict between Astra Pro button styles and Warder's preferences toggle component.
Impact: Visual regression only. No functional changes.