### PR TITLE
Confirm WordPress 7.1 compatibility, bump to 2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Warder Cookie Consent are documented here.
 
+## [2.1.6] - 2026-08-13
+
+### Compatibility
+- Confirmed compatibility with WordPress 7.1 and updated `Tested up to` to 7.1. No code changes were required: the plugin does not interact with the post editor canvas/iframe, client-side media processing, `@wordpress/components`, the admin toolbar, or jQuery UI.
+
 ## [2.1.5] - 2026-06-26
 
 ### Fixed

--- a/dist/cookieconsent.bundle.js
+++ b/dist/cookieconsent.bundle.js
@@ -1,5 +1,5 @@
 /*!
- * Warder Cookie Consent v2.1.5
+ * Warder Cookie Consent v2.1.6
  * This file is compiled from human-readable source with webpack.
  * Source: src/index.js (shipped in this plugin) + webpack.config.js
  * Repository: https://github.com/imagewize/warder-cookie-consent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imwz-cookie-consent",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "ISC",
       "dependencies": {
         "vanilla-cookieconsent": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imwz-cookie-consent",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: rhand, gbogdan
 Donate link: https://imagewize.com
 Tags: cookie, consent, gdpr, privacy, compliance
 Requires at least: 5.0
-Tested up to: 7.0
-Stable tag: 2.1.5
+Tested up to: 7.1
+Stable tag: 2.1.6
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -67,6 +67,11 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 5. Regex cookie matching and adding custom categories
 
 == Changelog ==
+
+= 2.1.6 =
+*2026-08-13*
+
+* Confirmed compatibility with WordPress 7.1 and updated `Tested up to`.
 
 = 2.1.5 =
 *2026-06-26*
@@ -231,6 +236,9 @@ Yes. Settings are versioned via a timestamp that is appended to the script URL, 
 * Initial release
 
 == Upgrade Notice ==
+
+= 2.1.6 =
+Confirms compatibility with WordPress 7.1. No functional changes.
 
 = 2.1.5 =
 Fixes a visual regression when Astra Pro is active: the floating preferences toggle button was inheriting button padding from the theme, distorting its shape and hiding the icon.

--- a/warder-cookie-consent.php
+++ b/warder-cookie-consent.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Warder Cookie Consent
  * Description: GDPR-compliant cookie consent banner with category management and floating preferences toggle.
- * Version: 2.1.5
+ * Version: 2.1.6
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * Requires at least: 5.0
@@ -16,7 +16,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WARDER_VERSION', '2.1.5' );
+define( 'WARDER_VERSION', '2.1.6' );
 define( 'WARDER_PLUGIN_FILE', __FILE__ );
 
 require_once plugin_dir_path( __FILE__ ) . 'inc/defaults.php';


### PR DESCRIPTION
Version 2.1.6 confirms compatibility with the newly released WordPress 7.1, updating the plugin's tested-up-to metadata without introducing functional changes to the cookie consent logic. The release rebuilds the distributed JavaScript bundle so the embedded version banner matches the plugin's PHP header, keeping the in-repo artifact aligned with the tagged release per the project's versioning workflow. Documentation and changelog files are updated in tandem to reflect the new version and compatibility confirmation, and `package.json` is bumped to keep all version references consistent across the codebase.

**Version and Compatibility Updates:**
- Bumped the plugin version to 2.1.6 in `warder-cookie-consent.php` (`Version:` header and `WARDER_VERSION` constant), confirming compatibility with WordPress 7.1.
- Updated `readme.txt` with the new `Stable tag` and a corresponding `Tested up to` entry to reflect WordPress 7.1 support.
- Synced `package.json` `version` field to 2.1.6 to keep it consistent with the plugin header, even though the package is not published to npm.

**Build Artifacts and Changelog:**
- Rebuilt `dist/cookieconsent.bundle.js` so its embedded version banner reflects 2.1.6, following the documented pre-tag build step.
- Added a new 2.1.6 entry to `CHANGELOG.md` documenting the WordPress 7.1 compatibility confirmation.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/warder-cookie-consent/blob/release/2.1.6-wp-7.1-compat/CHANGELOG.md) (Modified)
- [`dist/cookieconsent.bundle.js`](https://github.com/imagewize/warder-cookie-consent/blob/release/2.1.6-wp-7.1-compat/dist/cookieconsent.bundle.js) (Modified)
- [`package.json`](https://github.com/imagewize/warder-cookie-consent/blob/release/2.1.6-wp-7.1-compat/package.json) (Modified)
- [`readme.txt`](https://github.com/imagewize/warder-cookie-consent/blob/release/2.1.6-wp-7.1-compat/readme.txt) (Modified)
- [`warder-cookie-consent.php`](https://github.com/imagewize/warder-cookie-consent/blob/release/2.1.6-wp-7.1-compat/warder-cookie-consent.php) (Modified)

*Dependency lock files updated:* package-lock.json,